### PR TITLE
feat: Add Hyperliquid data source, multi-provider LLM advisor, paper trading, and multi-source backtesting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,23 @@ POLYMARKET_US_SECRET_KEY=your_base64_secret_key_here
 # Recommended: info or debug for monitoring
 RUST_LOG=info,dradis=info
 
+# ── Market data source (optional) ─────────────────────────────────────────────
+# Which external source feeds the raptor layer (spot price, velocity, funding,
+# open interest, taker flow). Applies to the International CLOB build only
+# (the us_retail build uses no raptors). Default is Binance.
+#   binance     — Binance Spot WS + FAPI REST (DEFAULT; the same behavior you get
+#                 by leaving this unset)
+#   hyperliquid — Hyperliquid public Info API, one WS raptor per asset
+#                 (trades → oracle/velocity/CVD, activeAssetCtx → funding×8/OI)
+# `hyperliquid` needs the DEFAULT cargo features (the SDK is gated behind the
+# additive `hyperliquid` feature); a build compiled without it logs an error and
+# falls back to Binance — it never panics.
+# CAVEAT: Polymarket crypto markets typically RESOLVE on Binance prices, so
+# running hyperliquid means the oracle/strike references may deviate slightly
+# from the actual resolution source. Operator trade-off (e.g. regions where
+# Binance is unreachable) — prefer binance unless you have a specific reason.
+# MARKET_DATA_SOURCE=binance
+
 # ── Control Tower UI Auth (RECOMMENDED for production) ───────────────────────
 # If set, the Control Tower dashboard requires HTTP Basic Auth.
 # Leave unset for local development (no login prompt).
@@ -139,3 +156,68 @@ RUST_LOG=info,dradis=info
 # US-session gating only; pulse held at 0, "Tide Raptor" pill shows offline).
 # ALPACA_API_KEY_ID=your_alpaca_key_id_here
 # ALPACA_API_SECRET_KEY=your_alpaca_secret_key_here
+
+# ── LLM Advisor (optional background task) ───────────────────────────────────
+# A periodic task that analyses recent trades with an LLM and posts optimization
+# recommendations to Telegram + the Control Tower.  Provider is selected at
+# RUNTIME (no rebuild).  Defaults preserve the historical Ollama behaviour, so an
+# existing deployment that only sets OLLAMA_URL/OLLAMA_MODEL keeps working
+# unchanged.  Compile-time defaults live in src/config.rs (LLM_PROVIDER, LLM_MODEL,
+# LLM_BASE_URL, LLM_CLOUD_TIMEOUT_SECS, LLM_OLLAMA_URL, LLM_OLLAMA_MODEL).
+#
+# Master switch (truthy = 1/true/yes/on, case-insensitive). Overrides config::ENABLE_LLM_ADVISOR.
+# ENABLE_LLM_ADVISOR=true
+#
+# Provider: ollama | anthropic | openai | openai-compatible | chatgpt
+# (aliases: openai_compatible/compat ; chatgpt-oauth/openai-oauth). Default: ollama.
+# LLM_PROVIDER=ollama
+#
+# Generic model name for the selected provider.  Empty = for ollama fall back to
+# OLLAMA_MODEL/LLM_OLLAMA_MODEL; for cloud providers a model name is REQUIRED.
+# LLM_MODEL=
+#
+# Generic base-URL override.  Used by ollama and (REQUIRED for) openai-compatible;
+# also an optional override for openai / anthropic.  Empty = provider default.
+# LLM_BASE_URL=
+
+# ── ollama (default provider) ────────────────────────────────────────────────
+# Point at a local or remote Ollama instance. These LEGACY vars are still honoured
+# and take precedence over config defaults (LLM_BASE_URL/LLM_MODEL win over these).
+# OLLAMA_URL=http://localhost:11434
+# OLLAMA_MODEL=llama3.2
+
+# ── anthropic (Claude) ───────────────────────────────────────────────────────
+# LLM_PROVIDER=anthropic
+# LLM_MODEL=claude-3-5-sonnet-latest
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# ── openai (OpenAI platform, Chat Completions API) ───────────────────────────
+# LLM_PROVIDER=openai
+# LLM_MODEL=gpt-4o-mini
+# OPENAI_API_KEY=sk-...
+
+# ── openai-compatible (vLLM / LM Studio / OpenRouter / Groq …) ───────────────
+# LLM_BASE_URL is REQUIRED. Include the /v1 suffix if your server needs it.
+# Many local servers need no key (a dummy key is sent automatically); set
+# OPENAI_API_KEY for hosted gateways like OpenRouter.
+# LLM_PROVIDER=openai-compatible
+# LLM_BASE_URL=http://localhost:1234/v1
+# LLM_MODEL=qwen2.5-7b-instruct
+# OPENAI_API_KEY=              # leave unset for keyless local servers
+
+# ── chatgpt ("Sign in with ChatGPT" OAuth subscription) ──────────────────────
+# NOTE: this bills to a ChatGPT subscription, NOT to OpenAI API credits.
+# Two ways to authenticate:
+#   1) Explicit access token (simplest for headless servers):
+#        CHATGPT_ACCESS_TOKEN=<oauth-access-token>
+#        CHATGPT_ACCOUNT_ID=<optional-account-id>
+#   2) OAuth token file (auto-refreshes): leave CHATGPT_ACCESS_TOKEN unset and
+#      place a rig-format auth.json at ~/.config/chatgpt/auth.json
+#      ({"access_token","refresh_token","id_token","expires_at","account_id"}),
+#      or point CHATGPT_AUTH_FILE at another file. A missing/expired token with no
+#      refresh triggers an interactive device-code login (unsuitable for headless).
+# LLM_PROVIDER=chatgpt
+# LLM_MODEL=gpt-5.3-codex
+# CHATGPT_ACCESS_TOKEN=
+# CHATGPT_ACCOUNT_ID=
+# CHATGPT_AUTH_FILE=

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,5 +40,20 @@ jobs:
     - name: Check
       run: cargo check --verbose
 
+    # Prove the additive `hyperliquid` feature is cleanly strippable: the engine
+    # must still compile (and fall back to Binance) with it disabled.
+    - name: Check (no hyperliquid feature)
+      run: cargo check --no-default-features --features intl_clob --verbose
+
     - name: Run tests
       run: cargo test --verbose
+
+    # Backtesting subsystem (non-default `backtest` feature). rs-backtester drags an
+    # unconditional plotting/font stack that needs system libfontconfig1-dev +
+    # pkg-config to build, so this is a SEPARATE step — default builds above never
+    # pay that cost. hyperliquid-backtest is deliberately NOT a dependency.
+    - name: Install backtest system deps
+      run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev pkg-config
+
+    - name: Check (backtest feature)
+      run: cargo check --features backtest --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 **/*.rs.bk
 Cargo.lock
 
+# Backtest runtime artifacts (SQLite cache + report output)
+backtest_cache.sqlite
+backtest_out/
+
 # Environment / Secrets (CRITICAL - Never commit!)
 .env
 .env.*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,14 @@ hyperliquid = ["dep:hyperliquid_rust_sdk"]
 # Historical replay backtesting subsystem (src/backtest/, src/bin/backtest.rs).
 # NOT in `default` — pulls rs-backtester's plotting/font stack (needs system
 # libfontconfig1-dev + pkg-config to build). See README "Backtesting".
-backtest = ["dep:rs-backtester"]
+backtest = ["dep:rs-backtester", "dep:clap"]
 
 [dependencies]
 polymarket_client_sdk_v2 = { version = "0.5.1", optional = true, features = ["clob", "ws", "data", "ctf"] }
 alloy = { version = "1.3", optional = true, features = ["signer-local"] }
 polymarket-us = { version = "0.3.5", optional = true }
 hyperliquid_rust_sdk = { version = "0.6.0", optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 dashmap = { version = "6", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,20 @@ description = "Low-latency Rust prediction-market trading bot for Polymarket. Si
 # The intl-only crypto deps (`alloy`, the Polymarket SDK) are gated behind
 # `intl_clob` so a `us_retail` build does not drag them into its dependency tree.
 [features]
-default   = ["intl_clob"]
+default   = ["intl_clob", "hyperliquid"]
 intl_clob = ["dep:polymarket_client_sdk_v2", "dep:alloy"]
 us_retail = ["dep:polymarket-us"]
+hyperliquid = ["dep:hyperliquid_rust_sdk"]
+# Historical replay backtesting subsystem (src/backtest/, src/bin/backtest.rs).
+# NOT in `default` — pulls rs-backtester's plotting/font stack (needs system
+# libfontconfig1-dev + pkg-config to build). See README "Backtesting".
+backtest = ["dep:rs-backtester"]
 
 [dependencies]
 polymarket_client_sdk_v2 = { version = "0.5.1", optional = true, features = ["clob", "ws", "data", "ctf"] }
 alloy = { version = "1.3", optional = true, features = ["signer-local"] }
 polymarket-us = { version = "0.3.5", optional = true }
+hyperliquid_rust_sdk = { version = "0.6.0", optional = true }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 dashmap = { version = "6", features = ["serde"] }
@@ -49,3 +55,21 @@ perpetual = "3.0.0-rc.2"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
+# Multi-provider LLM backend for the LLM Advisor (ollama / anthropic / openai /
+# openai-compatible / chatgpt-OAuth). All rig usage is confined to
+# src/helpers/llm_client.rs behind a DRADIS-owned trait.
+rig-core = "0.39"
+
+# ── Backtesting (feature = "backtest", non-default) ──────────────────────────
+# rs-backtester supplies Sharpe/drawdown/win-rate metrics + CSV on a directional
+# proxy of the underlying. It unconditionally drags a plotting/font stack
+# (needs system libfontconfig1-dev + pkg-config). NEVER call its plot()/i_chart()
+# on Linux (hard-coded Windows path join). We only read `Backtest.metrics` and
+# call `report_horizontal`. hyperliquid-backtest is deliberately NOT used (its
+# advertised API is unreachable dead code — see docs/BACKTEST notes).
+rs-backtester = { version = "0.1", optional = true }
+
+[[bin]]
+name = "backtest"
+path = "src/bin/backtest.rs"
+required-features = ["backtest"]

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ The stored recommendation is tagged `provider/model` (e.g. `anthropic/claude-3-5
 
 ## Backtesting (`backtest` feature)
 
-An offline harness that replays historical **Hyperliquid** 1-minute candles + funding
+An offline harness that replays historical market data (selectable provider: Hyperliquid or Binance FAPI)
 through the **real viper strategies** (the same `Strategy` objects the live bot runs),
 behind the clock seam so warmup / staleness / cooldown / hold-time gates evaluate
 against *historical* time at any replay speed. It is behind a **non-default** cargo
@@ -468,9 +468,13 @@ feature so normal builds/CI never pay its cost.
 # System deps (rs-backtester drags a plotting/font stack):
 sudo apt-get install -y libfontconfig1-dev pkg-config
 
-# Replay the last ~5h of BTC through every viper:
+# Replay the last ~5h of BTC through every viper (Hyperliquid data, default):
 cargo run --features backtest --bin backtest -- \
   --coin BTC --start now-6h --end now-1h
+
+# Same, but from Binance FAPI perp data (no ~5000-candle retention limit):
+cargo run --features backtest --bin backtest -- \
+  --coin BTC --start now-6h --end now-1h --source binance
 
 # Sweep a subset with a custom book model:
 cargo run --features backtest --bin backtest -- \
@@ -478,6 +482,19 @@ cargo run --features backtest --bin backtest -- \
   --strategies momentum,trendreversal --spread 0.02 --depth 500 --commission 0.0 \
   --out backtest_out --cache backtest_cache.sqlite
 ```
+
+### Historical Data Source
+
+By default, backtests pull from **Hyperliquid** (`--source hyperliquid`). Optionally, use `--source binance` to pull from **Binance FAPI** perpetual futures data instead:
+
+| Option | Provider | Notes |
+|--------|----------|-------|
+| `--source hyperliquid` (default) | Hyperliquid public info API | Native hourly funding; retains only the most recent ~5000 candles per interval (≈3.5 days at 1m) — older windows are unfetchable |
+| `--source binance` | Binance FAPI perps | Native per-8h funding; deep lookback (no ~5000-candle retention limit) |
+
+Both sources accept the same `--interval` values (`1m 3m 5m 15m 30m 1h 2h 4h 6h 8h 12h 1d 3d 1w`); anything else is rejected up front rather than silently mis-paginated. Candles and funding are cached per-source in the same SQLite file (`--cache`), so switching `--source` never contaminates the other source's rows; pre-existing caches are migrated in place (tagged `hyperliquid`) on first open.
+
+No API keys are involved: both providers' market-data endpoints are public and unauthenticated (Hyperliquid's info API has no auth field at all; Binance market data is rate-limited by IP, not key).
 
 Each run prints a per-strategy table (trades / win-rate / native PnL), the
 rs-backtester Sharpe/drawdown/win-rate, and a **fidelity-tier disclaimer**, and writes
@@ -493,8 +510,8 @@ rs-backtester Sharpe/drawdown/win-rate, and a **fidelity-tier disclaimer**, and 
 - **Tier A** — `drift_10m`/`drift_60m` gates and strike-distance gates are faithful.
 - **Tier B** — velocity gates: `velocity_5s`/`velocity_1s` come from 1m closes at 60s
   steps, so sub-5s windows are ~0 (velocity-gated logic is approximate). Funding is a
-  real historical series (HL hourly rate **×8**-normalized onto Binance's per-8h scale;
-  funding is a **signal only** — binary shares pay no carry).
+  real historical series (normalized onto Binance's canonical per-8h scale; funding is a
+  **signal only** — binary shares pay no carry).
 - **Tier C** — the 8 Polymarket book fields are a parametric binary-option model
   (`--spread`/`--depth`), **not** a real order book; OI/CVD and
   `institutional_pulse`/`tide_coherence` have no historical source (= 0), so

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ ASSETS=us                          # keep the dashboard pool tidy (US data lives
 ┌─────────────────────────────────────────────────────────────────────┐
 │                         src/ layout                                 │
 │                                                                     │
-│  raptors/          ← Signal scouts (Binance WS + FAPI REST)         │
+│  raptors/          ← Signal scouts (Binance or Hyperliquid)         │
 │  vipers/           ← Trading strategies (8 Vipers)                  │
 │  squadron/         ← Deployment layer (Raptor+Viper+Market bundle)  │
 │  cag/              ← Commander (async dispatch, multi-asset)        │
@@ -150,11 +150,11 @@ ASSETS=us                          # keep the dashboard pool tidy (US data lives
 ┌──────────────────────┐   ┌──────────────────────┐
 │    src/raptors/      │   │  Polymarket CLOB     │
 │  Price Raptor        │   │  (WebSocket Feed)    │
-│  (Binance Spot WS)   │   │                      │
+│  (Binance/Hyperliq)  │   │                      │
 │  Funding Raptor      │   │                      │
-│  (Binance FAPI REST) │   │                      │
+│  (Binance/Hyperliq)  │   │                      │
 │  Derivatives Raptor  │   │                      │
-│  (Binance FAPI: OI)  │   │                      │
+│  (Binance/Hyperliq)  │   │                      │
 │  Tide Raptor         │   │                      │
 │  (Alpaca IEX + iNAV) │   │                      │
 └──────────┬───────────┘   └───────────┬──────────┘
@@ -233,14 +233,22 @@ Raptors are intentionally dumb: **fetch, normalize, broadcast** — no trading l
 
 | Raptor                         | Source                  | Signal                                                  | Module                   |
 |--------------------------------|-------------------------|---------------------------------------------------------|--------------------------|
-| **Price Raptor**               | Binance Spot WS         | spot price, 5s/1s velocity, acceleration, 10m/60m drift | `src/raptors/price.rs`   |
-| **Funding Raptor**             | Binance Perpetuals FAPI | Perpetual funding rate (smart-money sentiment)          | `src/raptors/funding.rs` |
-| **Derivatives Raptor**         | Binance Perpetuals FAPI | Open-interest delta + taker CVD ratio (positioning pressure, all-asset) | `src/raptors/derivatives.rs` |
+| **Price Raptor**               | Binance or Hyperliquid (`MARKET_DATA_SOURCE`) | spot price, 5s/1s velocity, acceleration, 10m/60m drift | `src/raptors/price.rs`   |
+| **Funding Raptor**             | Binance or Hyperliquid (`MARKET_DATA_SOURCE`) | Perpetual funding rate (smart-money sentiment)          | `src/raptors/funding.rs` |
+| **Derivatives Raptor**         | Binance or Hyperliquid (`MARKET_DATA_SOURCE`) | Open-interest delta + taker CVD ratio (positioning pressure, all-asset) | `src/raptors/derivatives.rs` |
 | **Tide Raptor**                | Alpaca IEX + synthetic iNAV | "Institutional Pulse" + coherence from spot-BTC-ETF (IBIT/FBTC/ARKB) premium vs iNAV — BTC-only, US-hours | `src/raptors/tide.rs` |
 | *(future)* **Sports Raptor**   | Line movement APIs      | Betting line drift, public money %                      | —                        |
 | *(future)* **Politics Raptor** | Polling aggregators     | Approval drift, event probability shifts                | —                        |
 
 When multiple Raptors are active, the GBoost Viper fuses every signal as model features (funding, OI/CVD, institutional pulse/coherence); Basis, Momentum and TrendCapture use them as confirmation gates; and the **Convergence** Viper opens directional positions only when the institutional + derivatives stack agrees. No single Raptor has veto power alone.
+
+### Market data source: Binance or Hyperliquid
+
+The Price / Funding / Derivatives Raptors read from a runtime-selectable **market-data source**. The default is Binance; set `MARKET_DATA_SOURCE=hyperliquid` (env var, or `MARKET_DATA_SOURCE` in `src/config.rs`) to feed the raptor layer from the [Hyperliquid](https://hyperliquid.xyz) public Info API instead. This is a **data source only** — no keys, no signing, no trading; execution stays on Polymarket.
+
+- **Enable:** `MARKET_DATA_SOURCE=hyperliquid` on the default build (the `hyperliquid` cargo feature ships in `default`). On a build compiled without that feature the engine logs an error and falls back to Binance — it never panics.
+- **What maps to what:** one WS raptor per asset replaces the Binance trio. `Trades{coin}` → oracle price + 5s/1s velocity + acceleration + 10m/60m drift + rolling taker **CVD**; `ActiveAssetCtx{coin}` → funding rate (Hyperliquid quotes an **hourly** rate, so DRADIS emits it **×8** to match Binance's per-8h `lastFundingRate` semantics that the viper thresholds are tuned on) + **open interest** (sampled on the same 30s cadence as the Binance OI delta).
+- **Resolution-source caveat (read this):** Polymarket's crypto "Up or Down" markets typically **resolve on Binance prices**. Running `MARKET_DATA_SOURCE=hyperliquid` means the oracle and strike-price references DRADIS trades against may deviate slightly from the market's actual resolution source. This is an intentional operator trade-off — useful e.g. in regions where Binance is unreachable — not a free swap. Prefer Binance unless you have a specific reason.
 
 ---
 
@@ -348,9 +356,9 @@ DRADIS ships with a real-time web dashboard called **Control Tower** built on Ne
 
 ### Live Config Editing
 
-Every parameter in the Viper cards maps directly to the runtime `DynamicConfig`. Editing a value sends `PATCH /api/config` — **no restart required**. Changes take effect on the next 50ms tick.
+Every parameter in the Viper cards maps directly to the runtime `DynamicConfig`. Editing a value sends `PATCH /api/config` — **no restart required**. The edit is fanned out to every squadron's config row and reaches running squadrons within ~30 seconds (each squadron reloads its config on a periodic timer).
 
-> **Hot-Enable Design** — All eight Vipers are always instantiated at startup. The `DynamicConfig` enable flags are the sole runtime gate. Toggle any Viper on or off during a live session with immediate effect.
+> **Hot-Enable Design** — All eight Vipers are always instantiated at startup. The `DynamicConfig` enable flags are the sole runtime gate. Toggle any Viper on or off during a live session; the change takes effect on running squadrons within ~30 seconds.
 
 ### Authentication
 
@@ -364,22 +372,140 @@ CT_PASSWORD=your-strong-password
 
 ## LLM Advisor
 
-Optional background task. Every `LLM_ADVISOR_INTERVAL_SECS` (default: 30 min) it fetches recent trades from SQLite, analyzes them with a local Ollama model, and posts plain-English optimization recommendations to Telegram.
+Optional background task. Every `LLM_ADVISOR_INTERVAL_SECS` (default: 30 min) it fetches recent trades from SQLite, analyzes them with an LLM, and posts plain-English optimization recommendations to Telegram + the Control Tower.
+
+The backend is **provider-neutral** and selected at **runtime** (no rebuild). All provider wiring lives behind a small DRADIS-owned trait in `src/helpers/llm_client.rs` (built on [`rig-core`](https://crates.io/crates/rig-core)); the advisor loop only ever sees a `Box<dyn LlmChat>`. The default is Ollama, so existing deployments that only set `OLLAMA_URL`/`OLLAMA_MODEL` keep working **unchanged** (same endpoints, `num_ctx=3072`/`num_predict=900`/`temperature=0.3`, same timeouts and probe).
+
+### Provider matrix
+
+| `LLM_PROVIDER` | Backend | Auth | Base URL |
+|---|---|---|---|
+| `ollama` (default) | Local/remote Ollama (`/api/chat`) | none | `LLM_BASE_URL` → `OLLAMA_URL` → default `http://localhost:11434` |
+| `anthropic` | Claude models | `ANTHROPIC_API_KEY` | optional override via `LLM_BASE_URL` |
+| `openai` | OpenAI platform (Chat Completions) | `OPENAI_API_KEY` | optional override via `LLM_BASE_URL` |
+| `openai-compatible` | vLLM / LM Studio / OpenRouter / Groq … | `OPENAI_API_KEY` (optional) | **required** `LLM_BASE_URL` |
+| `chatgpt` | "Sign in with ChatGPT" OAuth | subscription token / OAuth file | — |
+
+### Configuration
 
 ```rust
-// src/config.rs
+// src/config.rs — compile-time defaults
 pub const ENABLE_LLM_ADVISOR: bool = true;
 pub const LLM_ADVISOR_INTERVAL_SECS: u64 = 1800;
-pub const LLM_ADVISOR_TRADES_LOOKBACK: i64 = 20;
+pub const LLM_PROVIDER: &str = "ollama";      // ollama|anthropic|openai|openai-compatible|chatgpt
+pub const LLM_MODEL: &str = "";               // "" = ollama uses LLM_OLLAMA_MODEL; cloud requires a value
+pub const LLM_BASE_URL: &str = "";            // "" = provider default (ollama falls back to LLM_OLLAMA_URL)
+pub const LLM_CLOUD_TIMEOUT_SECS: u64 = 120;  // cloud inference timeout (ollama keeps LLM_INFERENCE_TIMEOUT_SECS=480)
 pub const LLM_OLLAMA_URL: &str = "http://localhost:11434";
 pub const LLM_OLLAMA_MODEL: &str = "llama3.2";
 ```
 
+Everything is overridable at runtime via env (`.env`), no rebuild required. See `.env.example` for the full list.
+
+### Per-provider setup
+
+**Ollama (default — unchanged):**
 ```bash
-# Override at runtime without rebuilding
-OLLAMA_URL=http://192.168.1.10:11434
+# ollama pull llama3.2
+OLLAMA_URL=http://192.168.1.10:11434   # legacy vars still honoured
 OLLAMA_MODEL=mistral
 ```
+
+**Anthropic (Claude):**
+```bash
+LLM_PROVIDER=anthropic
+LLM_MODEL=claude-3-5-sonnet-latest
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**OpenAI:**
+```bash
+LLM_PROVIDER=openai
+LLM_MODEL=gpt-4o-mini
+OPENAI_API_KEY=sk-...
+```
+
+**OpenAI-compatible (LM Studio / OpenRouter / vLLM / Groq):** `LLM_BASE_URL` is required — include the `/v1` suffix if your server needs it. Local servers are usually keyless (a dummy key is sent automatically); hosted gateways like OpenRouter need `OPENAI_API_KEY`.
+```bash
+# LM Studio (keyless, local)
+LLM_PROVIDER=openai-compatible
+LLM_BASE_URL=http://localhost:1234/v1
+LLM_MODEL=qwen2.5-7b-instruct
+
+# OpenRouter (hosted)
+LLM_PROVIDER=openai-compatible
+LLM_BASE_URL=https://openrouter.ai/api/v1
+LLM_MODEL=meta-llama/llama-3.1-8b-instruct
+OPENAI_API_KEY=sk-or-...
+```
+
+**ChatGPT (OAuth subscription):** authenticates against the "Sign in with ChatGPT" backend. **This bills to a ChatGPT subscription, not to OpenAI API credits.** Simplest for a headless server is an explicit access token; otherwise place a rig-format `auth.json` (auto-refreshing) at `~/.config/chatgpt/auth.json` or point `CHATGPT_AUTH_FILE` at your own file. A missing/expired token with no refresh triggers an interactive device-code login (not suitable for headless).
+```bash
+LLM_PROVIDER=chatgpt
+LLM_MODEL=gpt-5.3-codex
+CHATGPT_ACCESS_TOKEN=<oauth-access-token>   # or leave unset to use the OAuth auth.json
+# CHATGPT_ACCOUNT_ID=<optional>
+# CHATGPT_AUTH_FILE=/path/to/auth.json
+```
+
+The stored recommendation is tagged `provider/model` (e.g. `anthropic/claude-3-5-sonnet-latest`) and rendered as the Control Tower badge.
+
+---
+
+## Backtesting (`backtest` feature)
+
+An offline harness that replays historical **Hyperliquid** 1-minute candles + funding
+through the **real viper strategies** (the same `Strategy` objects the live bot runs),
+behind the clock seam so warmup / staleness / cooldown / hold-time gates evaluate
+against *historical* time at any replay speed. It is behind a **non-default** cargo
+feature so normal builds/CI never pay its cost.
+
+```bash
+# System deps (rs-backtester drags a plotting/font stack):
+sudo apt-get install -y libfontconfig1-dev pkg-config
+
+# Replay the last ~5h of BTC through every viper:
+cargo run --features backtest --bin backtest -- \
+  --coin BTC --start now-6h --end now-1h
+
+# Sweep a subset with a custom book model:
+cargo run --features backtest --bin backtest -- \
+  --coin BTC --start 2026-07-01T00:00:00Z --end 2026-07-01T06:00:00Z \
+  --strategies momentum,trendreversal --spread 0.02 --depth 500 --commission 0.0 \
+  --out backtest_out --cache backtest_cache.sqlite
+```
+
+Each run prints a per-strategy table (trades / win-rate / native PnL), the
+rs-backtester Sharpe/drawdown/win-rate, and a **fidelity-tier disclaimer**, and writes
+`report.json` + `trades.csv` + `equity.csv` into `--out`.
+
+**Two PnL views, deliberately:**
+1. **Native Decimal ledger** (authoritative) — prices the actual binary YES/NO shares
+   and settles 0/1 at expiry vs strike.
+2. **rs-backtester metrics** (directional proxy) — `BUY/SHORTSELL/NULL` on the
+   underlying candle series; a linear-instrument proxy, **not** the binary payoff.
+
+**Honest fidelity tiers** (printed with every result):
+- **Tier A** — `drift_10m`/`drift_60m` gates and strike-distance gates are faithful.
+- **Tier B** — velocity gates: `velocity_5s`/`velocity_1s` come from 1m closes at 60s
+  steps, so sub-5s windows are ~0 (velocity-gated logic is approximate). Funding is a
+  real historical series (HL hourly rate **×8**-normalized onto Binance's per-8h scale;
+  funding is a **signal only** — binary shares pay no carry).
+- **Tier C** — the 8 Polymarket book fields are a parametric binary-option model
+  (`--spread`/`--depth`), **not** a real order book; OI/CVD and
+  `institutional_pulse`/`tide_coherence` have no historical source (= 0), so
+  **Convergence is excluded** (always no-ops) and **TrendReversal's SQLite cascade
+  guard no-ops**.
+
+The `--cache` SQLite file is separate from the live trading DB and fills gaps only
+(re-runs are free). `--llm-score` (experimental, off by default) asks the configured
+LLM provider for a 0–100 conviction score per entry and joins it against realized PnL
+in `report.json`; it degrades gracefully if no provider is configured, and API keys
+are never logged. `hyperliquid-backtest` is deliberately **not** a dependency — its
+advertised fetch/backtest/report API is unreachable dead code in the published crate.
+
+> ⚠️ On Linux, never call rs-backtester's `plot()`/`i_chart()` — they hard-code a
+> Windows path join. The harness only reads `Backtest.metrics` + `report_horizontal`.
 
 ---
 
@@ -626,11 +752,50 @@ The safe pattern: bump the suffix in `GBOOST_MODEL_PATH` (e.g. `v14f` → `v15f`
 
 **Why doesn't DRADIS include a backtesting framework?**
 
-| Concern              | Backtester                                                | Ghost Mode                                 |
-|----------------------|-----------------------------------------------------------|--------------------------------------------|
-| Market data fidelity | Requires storing full L2 orderbook snapshots              | Real-time Polymarket CLOB — 100% authentic |
-| Strategy fidelity    | Must mock async execution, cooldown maps, drawdown guards | Full production code path runs unchanged   |
-| Fill simulation      | Assumes fills that may never occur in thin markets        | No fills in ghost — no wishful thinking    |
-| Build/maintain cost  | Significant                                               | Zero — `GHOST_MODE = true` in `config.rs`  |
+| Concern              | Backtester                                                | Ghost (Paper) Mode                          |
+|----------------------|-----------------------------------------------------------|---------------------------------------------|
+| Market data fidelity | Requires storing full L2 orderbook snapshots              | Real-time Polymarket CLOB — 100% authentic  |
+| Strategy fidelity    | Must mock async execution, cooldown maps, drawdown guards | Full production code path runs unchanged    |
+| Fill simulation      | Assumes fills that may never occur in thin markets        | Depth-aware simulated fills (see below)     |
+| Build/maintain cost  | Significant                                               | Zero — flip the runtime GHOST/LIVE toggle   |
 
 Workflow: ghost overnight → `tools/session_parser.py` → tune `config.rs` → repeat until positive expectancy.
+
+**Paper trading (Ghost Mode)**
+
+The Control Tower GHOST/LIVE toggle is a real runtime switch, not just a badge. In the
+default `intl_clob` build it controls order placement live via the hot-patchable
+`DynamicConfig` — no rebuild required. The compiled `config::GHOST_MODE` constant now
+only *seeds* the initial toggle state (and is recorded in the startup config-history
+snapshot); it no longer gates trading.
+
+- **Position-scoped, grandfathered.** Each position permanently carries the mode it was
+  opened under. Flipping the toggle affects only NEW orders (within ~30 seconds on a
+  running squadron): open positions keep the mode they were opened with. Exits, orphan
+  sweeps, and expiry settlement all key off the position's own mode, never the current toggle.
+- **Depth-aware simulated fills.** Ghost entries fill up to the visible ask depth at the
+  requested price (± the usual offsets); any overflow fills one tranche worse by
+  `PAPER_OVERFLOW_SLIPPAGE` (default 2¢), weighted-averaged into `avg_entry`. Ghost exits
+  are symmetric against the bid. No more instant, full, frictionless fills.
+- **Resting maker quotes.** Ghost `MakerQuote`s no longer instafill. They rest in a
+  simulated queue and fill only after the market's best bid has sat at/below the quote
+  for `PAPER_MAKER_FILL_TICKS` (default 3) consecutive patrol ticks.
+- **Paper ledger.** A simulated collateral ledger is seeded from
+  `PAPER_STARTING_COLLATERAL` (default $1000). Ghost entries debit their cost and are
+  rejected (warn + skip) when the ledger is insufficient; ghost exits and settlements
+  credit their proceeds. Paper P&L and paper balance are tracked **separately** from live
+  money and surfaced on `GET /api/status` (`paper_pnl`, `paper_balance`) and in the
+  Control Tower's "Paper Ledger" card. As a result, `total_pnl` (the headline session
+  P&L) is now **live-only** — ghost activity no longer commingles into it.
+- **Binary expiry settlement.** Ghost positions that reach expiry without an explicit
+  exit now settle at their binary payout ($1 if the market resolved in the token's
+  favour vs. the strike, else $0) instead of silently vanishing — booking realized paper
+  P&L and recording a `expiry_settlement_sim` trade.
+- **Full DB parity.** Ghost exits and maker fills write the same rows live ones do
+  (`trades` + `open_positions`), and both the `trades` and `entries` tables now carry a
+  `ghost_mode` column, so paper and live history are cleanly separable across sessions.
+  The Control Tower badges ghost trades/positions with 👻 and labels ghost
+  notifications `👻 [PAPER]`.
+
+Not in scope (deliberately): credential-free boot — the default build still requires
+`POLYGON_RPC_URL` + a Polymarket-accepted key + live CLOB auth even in ghost mode.

--- a/control-tower/src/app/page.tsx
+++ b/control-tower/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import useSWR from 'swr';
 import dynamic from 'next/dynamic';
 
@@ -11,13 +11,14 @@ import SquadronsPanel  from '@/components/SquadronsPanel';
 import SquadronDetailView from '@/components/SquadronDetailView';
 import TradelogPage    from '@/components/TradelogPage';
 import ErrorBoundary   from '@/components/ErrorBoundary';
-import { getAssets, getConfig, getPnlHistory, getTrades, getOpenPositions, getHealth, patchConfig, VIPER_DEFS, getStatus, getLlmRecommendations, getPortfolioValue, getSquadrons } from '@/lib/api';
+import { getAssets, getConfig, getPnlHistory, getTrades, getOpenPositions, getHealth, patchConfig, VIPER_DEFS, getStatus, getLlmRecommendations, getPortfolioValue, getSquadrons, probeBacktest } from '@/lib/api';
 import { DEMO_MODE } from '@/lib/demo';
-import type { DynamicConfig, SquadronSummary } from '@/lib/types';
+import type { DynamicConfig, SquadronSummary, TradeRow } from '@/lib/types';
 
 // Recharts must be loaded client-side only
 const PnlChart = dynamic(() => import('@/components/PnlChart'), { ssr: false });
 const TelemetryPage = dynamic(() => import('@/components/TelemetryPage'), { ssr: false });
+const BacktestPage = dynamic(() => import('@/components/BacktestPage'), { ssr: false });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -106,10 +107,98 @@ function StatCard({ label, value, sub, valueClass = '' }: {
 function GhostBanner({ ghost }: { ghost: boolean }) {
   return ghost ? (
     <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg px-4 py-2 text-amber-300 text-xs font-mono flex items-center gap-2">
-      <span className="text-base"></span>
-      <span><strong>GHOST MODE ACTIVE</strong> — orders are simulated, no real CLOB calls.</span>
+      <span className="text-base">👻</span>
+      <span>
+        <strong>GHOST MODE ACTIVE</strong> — new orders are simulated (paper), no real CLOB calls.
+        Toggling affects NEW orders within ~30 seconds; open positions keep the mode they were opened with.
+      </span>
     </div>
   ) : null;
+}
+
+// ── Paper equity sparkline ────────────────────────────────────────────────────
+
+/** Tiny inline-SVG sparkline of the cumulative paper-equity series. No deps. */
+function PaperSparkline({ series, width = 132, height = 34 }: {
+  series: number[]; width?: number; height?: number;
+}) {
+  if (series.length < 2) return null;
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const span = max - min || 1;
+  const pad = 2;
+  const stepX = (width - pad * 2) / (series.length - 1);
+  const y = (v: number) => pad + (height - pad * 2) * (1 - (v - min) / span);
+  const pts = series.map((v, i) => `${(pad + i * stepX).toFixed(2)},${y(v).toFixed(2)}`).join(' ');
+  const up = series[series.length - 1] >= series[0];
+  const stroke = up ? '#4ade80' : '#f87171';
+  const baseY = y(series[0]);
+  return (
+    <svg width={width} height={height} className="overflow-visible" aria-hidden="true">
+      <line x1={pad} y1={baseY} x2={width - pad} y2={baseY} stroke="#334155" strokeWidth={1} strokeDasharray="3 3" />
+      <polyline points={pts} fill="none" stroke={stroke} strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+// ── Paper (ghost) ledger card ─────────────────────────────────────────────────
+
+function PaperLedgerCard({
+  paperPnl, paperBalance, paperTrades,
+}: {
+  paperPnl: number; paperBalance: number;
+  /** Ghost trades (ascending by ts) with realized pnl, from the already-fetched trades. */
+  paperTrades: { ts: number; pnl: number }[];
+}) {
+  const positive = paperPnl >= 0;
+
+  // Cumulative paper-equity series, ANCHORED so its endpoint equals the current Paper
+  // Balance headline. We can't anchor at a fixed all-time starting balance and sum
+  // forward: the fetched ghost trades are only the newest ~60 per asset (and may span
+  // prior sessions), whereas paperBalance/paperPnl are the current in-memory ledger, so a
+  // forward-summed curve's endpoint would silently disagree with the headline once trades
+  // are truncated or a session rolls over. Instead we walk BACKWARD from paperBalance:
+  // last point = balance, each earlier point subtracts the following trade's pnl. The
+  // endpoint is always consistent with the headline; the curve shows the shape of the
+  // fetched window. Purely client-side from the already-fetched trades — no backend.
+  const series = useMemo(() => {
+    const total = paperTrades.reduce((sum, t) => sum + t.pnl, 0);
+    let acc = paperBalance - total;
+    const pts = [acc];
+    for (const t of paperTrades) {
+      acc += t.pnl;
+      pts.push(acc);
+    }
+    return pts;
+  }, [paperBalance, paperTrades]);
+
+  return (
+    <div className="card px-5 py-3 flex flex-wrap items-center gap-x-8 gap-y-2 border border-amber-500/20 bg-[#0d0d1a]">
+      <div className="flex items-center gap-2">
+        <span className="text-base">👻</span>
+        <span className="label-muted text-xs">Paper Ledger</span>
+        <span className="text-[10px] font-mono bg-amber-500/10 text-amber-400 border border-amber-500/20 rounded px-1.5 py-0.5">
+          simulated
+        </span>
+      </div>
+      <div className="flex flex-col gap-0.5">
+        <span className="text-gray-500 text-xs font-mono">Paper P&amp;L</span>
+        <span className={`text-sm font-mono ${positive ? 'text-green-400' : 'text-red-400'}`}>
+          {(positive ? '+' : '') + fmt$(paperPnl)}
+        </span>
+      </div>
+      <div className="flex flex-col gap-0.5">
+        <span className="text-gray-500 text-xs font-mono">Paper Balance</span>
+        <span className="text-sm font-mono text-gray-300">{fmt$(paperBalance)}</span>
+      </div>
+      {series.length >= 2 && (
+        <div className="flex flex-col gap-0.5 ml-auto">
+          <span className="text-gray-500 text-[10px] font-mono">Paper Equity ({series.length - 1} trades)</span>
+          <PaperSparkline series={series} />
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ── Asset selector tabs ───────────────────────────────────────────────────────
@@ -227,19 +316,23 @@ function PortfolioValueBanner({
 
 // ── Top-level nav ─────────────────────────────────────────────────────────────
 
-type AppView = 'main' | 'telemetry' | 'tradelog';
+type AppView = 'main' | 'telemetry' | 'tradelog' | 'backtest';
 
 function NavTabs({
   active,
   onChange,
+  showBacktest,
 }: {
   active: AppView;
   onChange: (v: AppView) => void;
+  showBacktest: boolean;
 }) {
   const tabs: { id: AppView; label: string; icon: string }[] = [
     { id: 'main',      label: 'Main',      icon: '🗺️' },
     { id: 'telemetry', label: 'Telemetry', icon: '📡' },
     { id: 'tradelog',  label: 'Tradelog',  icon: '📋' },
+    // Backtest tab only when the feature-gated backend endpoint is present.
+    ...(showBacktest ? [{ id: 'backtest' as AppView, label: 'Backtest', icon: '🧪' }] : []),
   ];
   return (
     <div className="flex items-center gap-1">
@@ -332,6 +425,17 @@ export default function DashboardPage() {
   const { data: squadrons, isLoading: squadronsLoading } =
     useSWR('squadrons', getSquadrons, { refreshInterval: 10_000 });
 
+  // Probe once whether the feature-gated backtest API is present. Default builds
+  // omit those routes (404) → the Backtest tab stays hidden.
+  const { data: backtestAvailable = false } =
+    useSWR('backtest-available', probeBacktest, { refreshInterval: 0, revalidateOnFocus: false });
+
+  // If the tab is hidden but somehow active (e.g. backend restarted without the
+  // feature), fall back to Main so we never render a dead view.
+  useEffect(() => {
+    if (activeView === 'backtest' && !backtestAvailable) setActiveView('main');
+  }, [activeView, backtestAvailable]);
+
   // ── Stats derived from P&L history ──────────────────────────────────────────
   const latestSnap  = pnl?.[0];
   const oldestSnap  = pnl?.[pnl.length - 1];
@@ -377,7 +481,7 @@ export default function DashboardPage() {
                 <span className="font-mono font-bold text-lg tracking-wide text-indigo-400">DRADIS</span>
                 <span className="text-gray-600 text-lg">|</span>
               </div>
-              <NavTabs active={activeView} onChange={(v) => { setActiveView(v); setFocusedSquadronId(null); }} />
+              <NavTabs active={activeView} onChange={(v) => { setActiveView(v); setFocusedSquadronId(null); }} showBacktest={backtestAvailable} />
             </div>
 
             {/* Center — BSG motto */}
@@ -397,6 +501,7 @@ export default function DashboardPage() {
               {config && !DEMO_MODE && (
                 <button
                   onClick={() => handlePatch({ ghost_mode: !config.ghost_mode })}
+                  title="Affects NEW orders within ~30 seconds. Open positions keep the mode they were opened with (grandfathered); ghost positions stay simulated."
                   className={[
                     'flex items-center gap-2 text-xs font-mono px-3 py-1.5 rounded-lg border transition-colors',
                     config.ghost_mode
@@ -437,7 +542,7 @@ export default function DashboardPage() {
               <span className="font-mono font-bold text-lg tracking-wide text-indigo-400">DRADIS</span>
               <span className="text-gray-600 text-lg">|</span>
             </div>
-            <NavTabs active={activeView} onChange={setActiveView} />
+            <NavTabs active={activeView} onChange={setActiveView} showBacktest={backtestAvailable} />
           </div>
 
           {/* Center — BSG motto */}
@@ -457,6 +562,7 @@ export default function DashboardPage() {
             {config && !DEMO_MODE && (
               <button
                 onClick={() => handlePatch({ ghost_mode: !config.ghost_mode })}
+                title="Affects NEW orders within ~30 seconds. Open positions keep the mode they were opened with (grandfathered); ghost positions stay simulated."
                 className={[
                   'flex items-center gap-2 text-xs font-mono px-3 py-1.5 rounded-lg border transition-colors',
                   config.ghost_mode
@@ -498,6 +604,20 @@ export default function DashboardPage() {
         </main>
       )}
 
+      {/* ── Backtest view (feature-gated backend) ──────────────────────────── */}
+      {activeView === 'backtest' && backtestAvailable && (
+        <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-6">
+          {config?.ghost_mode && <GhostBanner ghost />}
+          <ErrorBoundary label="Backtest">
+            <BacktestPage availableAssets={availableAssets} />
+          </ErrorBoundary>
+          <footer className="text-center text-xs text-gray-700 pb-4 font-mono">
+            DRADIS Control Tower  Polymarket CLOB Orchestrator {' '}
+            <span className="text-gray-600">So say we all.</span>
+          </footer>
+        </main>
+      )}
+
       {/* ── Main view ──────────────────────────────────────────────────────── */}
       {activeView === 'main' && (
       <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-6">
@@ -517,6 +637,24 @@ export default function DashboardPage() {
           pricesLive={portfolio?.prices_live ?? true}
           isLoading={portfolioLoading}
         />
+
+        {/* ── Paper (ghost) ledger — shown when ghosting or any paper activity ── */}
+        {(() => {
+          const paperPnl = parseFloat(status?.paper_pnl ?? '0');
+          const paperBalance = parseFloat(status?.paper_balance ?? '0');
+          // Show when ghosting or once any paper activity has realized P&L. NOTE: do not
+          // test `paperBalance !== 0` — the ledger is seeded to PAPER_STARTING_COLLATERAL
+          // (1000) per squadron session, so it is always non-zero even for a pure-live
+          // operator; that made the card render permanently.
+          const show = (config?.ghost_mode ?? false) || paperPnl !== 0;
+          // Ghost trades across all assets, ascending by ts, for the equity sparkline.
+          const paperTrades = ((allTrades ?? []) as TradeRow[])
+            .filter(t => t.ghost_mode)
+            .map(t => ({ ts: new Date(t.ts).getTime(), pnl: parseFloat(t.pnl) }))
+            .filter(t => Number.isFinite(t.ts) && Number.isFinite(t.pnl))
+            .sort((a, b) => a.ts - b.ts);
+          return show ? <PaperLedgerCard paperPnl={paperPnl} paperBalance={paperBalance} paperTrades={paperTrades} /> : null;
+        })()}
 
         {/* ── Portfolio History Chart (CAG-level) ───────────────────────── */}
         {pnlLoading ? (
@@ -564,6 +702,8 @@ export default function DashboardPage() {
           recommendations={llmRecs ?? []}
           isLoading={llmLoading}
           advisorEnabled={true}
+          llmProvider={status?.llm_provider}
+          llmModel={status?.llm_model}
         />
 
         {/* ── CAG Squadron Registry ─────────────────────────────────────── */}

--- a/control-tower/src/components/BacktestPage.tsx
+++ b/control-tower/src/components/BacktestPage.tsx
@@ -1,0 +1,721 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine,
+} from 'recharts';
+import { getBacktestRuns, getBacktestRun, runBacktest } from '@/lib/api';
+import { DEMO_MODE } from '@/lib/demo';
+import type { BacktestRunRequest, BacktestRunStatus, BacktestTrade } from '@/lib/types';
+
+// ── Static option lists ───────────────────────────────────────────────────────
+
+/** Short strategy names accepted by the harness (`configure_enables`). Momentum and
+ *  Convergence are effectively excluded by the fidelity tiers (Tier B/C) but remain
+ *  selectable so the exclusion is visible in the results. */
+const STRATS: { value: string; label: string }[] = [
+  { value: 'trendreversal', label: 'TrendReversal' },
+  { value: 'gboost',        label: 'GBoost' },
+  { value: 'basis',         label: 'Basis' },
+  { value: 'maker',         label: 'Maker' },
+  { value: 'timedecay',     label: 'Time Decay' },
+  { value: 'arbitrage',     label: 'Arbitrage' },
+  { value: 'momentum',      label: 'Momentum' },
+  { value: 'convergence',   label: 'Convergence' },
+];
+
+const WINDOWS: { value: string; label: string }[] = [
+  { value: '6h',     label: '6h' },
+  { value: '24h',    label: '24h' },
+  { value: '72h',    label: '72h' },
+  { value: 'custom', label: 'Custom' },
+];
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+
+function fmtNum(v: string | number | null | undefined, dp = 2): string {
+  if (v === null || v === undefined) return '—';
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  return Number.isFinite(n) ? n.toFixed(dp) : '—';
+}
+
+function fmtPct(v: number | null | undefined, dp = 2): string {
+  if (v === null || v === undefined || !Number.isFinite(v)) return '—';
+  return `${v.toFixed(dp)}%`;
+}
+
+function fmtTs(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('en-US', {
+      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false,
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function fmtMs(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return '—';
+  return fmtTs(new Date(ms).toISOString());
+}
+
+function pnlClass(v: string | number | null | undefined): string {
+  if (v === null || v === undefined) return 'text-gray-400';
+  const n = typeof v === 'number' ? v : parseFloat(v);
+  if (!Number.isFinite(n)) return 'text-gray-400';
+  return n > 0 ? 'text-green-400' : n < 0 ? 'text-red-400' : 'text-gray-400';
+}
+
+const STATUS_META: Record<BacktestRunStatus, { label: string; cls: string; dot: string }> = {
+  running: { label: 'Running', cls: 'text-amber-300 border-amber-500/30 bg-amber-500/10', dot: 'bg-amber-400 animate-pulse' },
+  done:    { label: 'Done',    cls: 'text-green-300 border-green-500/30 bg-green-500/10', dot: 'bg-green-400' },
+  failed:  { label: 'Failed',  cls: 'text-red-300 border-red-500/30 bg-red-500/10',       dot: 'bg-red-500' },
+};
+
+// ── Small shared bits ─────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: BacktestRunStatus }) {
+  const m = STATUS_META[status];
+  return (
+    <span className={`inline-flex items-center gap-1.5 text-[10px] font-mono rounded px-1.5 py-0.5 border ${m.cls}`}>
+      <span className={`h-1.5 w-1.5 rounded-full ${m.dot}`} />
+      {m.label}
+    </span>
+  );
+}
+
+function Field({ label, children, hint }: { label: string; children: React.ReactNode; hint?: string }) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[11px] font-mono text-gray-500 uppercase tracking-wide">{label}</span>
+      {children}
+      {hint && <span className="text-[10px] font-mono text-gray-600">{hint}</span>}
+    </label>
+  );
+}
+
+// ── Run form ──────────────────────────────────────────────────────────────────
+
+function RunForm({
+  assets, busy, onRun,
+}: {
+  assets: string[];
+  busy: boolean;
+  onRun: (req: BacktestRunRequest) => Promise<void>;
+}) {
+  const [coin, setCoin] = useState<string>((assets[0] ?? 'btc').toUpperCase());
+  const [win, setWin] = useState<string>('24h');
+  const [customStart, setCustomStart] = useState<string>('');
+  const [customEnd, setCustomEnd] = useState<string>('');
+  const [interval, setIntervalStr] = useState<string>('1m');
+  const [spread, setSpread] = useState<string>('0.02');
+  const [depth, setDepth] = useState<string>('500');
+  const [commission, setCommission] = useState<string>('0');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [llmScore, setLlmScore] = useState<boolean>(false);
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const coinOptions = assets.length > 0 ? assets.map(a => a.toUpperCase()) : ['BTC', 'ETH', 'SOL'];
+
+  function toggleStrat(v: string) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(v)) next.delete(v); else next.add(v);
+      return next;
+    });
+  }
+
+  function resolveWindow(): { start: string; end: string } | { error: string } {
+    if (win === 'custom') {
+      if (!customStart || !customEnd) return { error: 'Custom window needs both a start and an end.' };
+      const s = new Date(customStart);
+      const e = new Date(customEnd);
+      if (Number.isNaN(s.getTime()) || Number.isNaN(e.getTime())) return { error: 'Invalid custom date/time.' };
+      if (e.getTime() <= s.getTime()) return { error: 'End must be after start.' };
+      return { start: s.toISOString(), end: e.toISOString() };
+    }
+    // Presets map onto the CLI's relative-time syntax (now-<N>h).
+    return { start: `now-${win}`, end: 'now' };
+  }
+
+  async function submit() {
+    setError(null);
+    const w = resolveWindow();
+    if ('error' in w) { setError(w.error); return; }
+
+    // Range-check the numeric knobs before submit. A negative half-spread synthesizes a
+    // crossed book on the backend and banks phantom profit into the "authoritative" ledger,
+    // so these bounds mirror the server-side guard in build_config().
+    const sp = Number(spread);
+    if (!Number.isFinite(sp) || sp < 0 || sp > 0.5) {
+      setError('Spread (book half-spread) must be a number between 0 and 0.5.');
+      return;
+    }
+    const dp = Number(depth);
+    if (!Number.isFinite(dp) || dp <= 0) {
+      setError('Depth must be a positive number of shares.');
+      return;
+    }
+    const cm = Number(commission);
+    if (!Number.isFinite(cm) || cm < 0 || cm >= 1) {
+      setError('Commission must be a rate between 0 and 1.');
+      return;
+    }
+
+    const req: BacktestRunRequest = {
+      coin,
+      start: w.start,
+      end: w.end,
+      interval,
+      spread,
+      depth,
+      commission,
+      llm_score: llmScore,
+    };
+    const strats = Array.from(selected);
+    if (strats.length > 0) req.strategies = strats;
+
+    setSubmitting(true);
+    try {
+      await onRun(req);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const disabled = submitting || busy || DEMO_MODE;
+
+  return (
+    <div className="card px-5 py-4 space-y-4 border border-indigo-500/20 bg-[#0d0d1a]">
+      <div className="flex items-center gap-2">
+        <span className="text-base">🧪</span>
+        <p className="label-muted text-xs">New Backtest Run</p>
+        {busy && (
+          <span className="text-[10px] font-mono text-amber-400/80">a run is in progress — one at a time</span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        <Field label="Coin">
+          <select
+            value={coin}
+            onChange={e => setCoin(e.target.value)}
+            className="bg-[#0a0a12] border border-[#1e1e32] rounded px-2 py-1.5 text-sm font-mono text-gray-200 focus:outline-none focus:border-indigo-500"
+          >
+            {coinOptions.map(c => <option key={c} value={c}>{c}</option>)}
+          </select>
+        </Field>
+
+        <Field label="Window">
+          <div className="flex flex-wrap gap-1">
+            {WINDOWS.map(w => (
+              <button
+                key={w.value}
+                type="button"
+                onClick={() => setWin(w.value)}
+                className={[
+                  'text-[11px] font-mono px-2.5 py-1 rounded border transition-colors',
+                  win === w.value
+                    ? 'bg-indigo-500/20 border-indigo-500/40 text-indigo-300'
+                    : 'bg-[#13131f] border-[#1e1e32] text-gray-500 hover:border-gray-600 hover:text-gray-300',
+                ].join(' ')}
+              >
+                {w.label}
+              </button>
+            ))}
+          </div>
+        </Field>
+
+        <Field label="Interval">
+          <select
+            value={interval}
+            onChange={e => setIntervalStr(e.target.value)}
+            className="bg-[#0a0a12] border border-[#1e1e32] rounded px-2 py-1.5 text-sm font-mono text-gray-200 focus:outline-none focus:border-indigo-500"
+          >
+            {['1m', '5m', '15m', '1h'].map(i => <option key={i} value={i}>{i}</option>)}
+          </select>
+        </Field>
+
+        <Field label="LLM scoring" hint="experimental — needs a provider">
+          <button
+            type="button"
+            onClick={() => setLlmScore(v => !v)}
+            className={[
+              'text-xs font-mono px-3 py-1.5 rounded border transition-colors w-fit',
+              llmScore
+                ? 'bg-violet-500/20 border-violet-500/40 text-violet-300'
+                : 'bg-[#13131f] border-[#1e1e32] text-gray-500 hover:border-gray-600 hover:text-gray-300',
+            ].join(' ')}
+          >
+            {llmScore ? '🤖 ON' : 'OFF'}
+          </button>
+        </Field>
+      </div>
+
+      {win === 'custom' && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Field label="Custom start">
+            <input
+              type="datetime-local"
+              value={customStart}
+              onChange={e => setCustomStart(e.target.value)}
+              className="bg-[#0a0a12] border border-[#1e1e32] rounded px-2 py-1.5 text-sm font-mono text-gray-200 focus:outline-none focus:border-indigo-500"
+            />
+          </Field>
+          <Field label="Custom end">
+            <input
+              type="datetime-local"
+              value={customEnd}
+              onChange={e => setCustomEnd(e.target.value)}
+              className="bg-[#0a0a12] border border-[#1e1e32] rounded px-2 py-1.5 text-sm font-mono text-gray-200 focus:outline-none focus:border-indigo-500"
+            />
+          </Field>
+        </div>
+      )}
+
+      <div className="grid grid-cols-3 gap-4">
+        <Field label="Spread (±)" hint="book half-spread (Tier C)">
+          <input value={spread} onChange={e => setSpread(e.target.value)} className="input-field w-full text-left" />
+        </Field>
+        <Field label="Depth (sh/side)" hint="modeled depth (Tier C)">
+          <input value={depth} onChange={e => setDepth(e.target.value)} className="input-field w-full text-left" />
+        </Field>
+        <Field label="Commission" hint="fee rate (0 = none)">
+          <input value={commission} onChange={e => setCommission(e.target.value)} className="input-field w-full text-left" />
+        </Field>
+      </div>
+
+      <Field label="Strategies" hint="none selected → all vipers enabled">
+        <div className="flex flex-wrap gap-1.5">
+          {STRATS.map(s => (
+            <button
+              key={s.value}
+              type="button"
+              onClick={() => toggleStrat(s.value)}
+              className={[
+                'text-[11px] font-mono px-2.5 py-1 rounded border transition-colors',
+                selected.has(s.value)
+                  ? 'bg-indigo-500/20 border-indigo-500/40 text-indigo-300'
+                  : 'bg-[#13131f] border-[#1e1e32] text-gray-500 hover:border-gray-600 hover:text-gray-300',
+              ].join(' ')}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </Field>
+
+      {error && (
+        <div className="text-xs font-mono text-red-400 bg-red-500/10 border border-red-500/20 rounded px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={disabled}
+          className={[
+            'text-sm font-mono px-4 py-2 rounded border transition-colors',
+            disabled
+              ? 'bg-[#13131f] border-[#1e1e32] text-gray-600 cursor-not-allowed'
+              : 'bg-indigo-500/20 border-indigo-500/40 text-indigo-200 hover:bg-indigo-500/30',
+          ].join(' ')}
+        >
+          {submitting ? 'Launching…' : '▶ Run Backtest'}
+        </button>
+        {DEMO_MODE && <span className="text-[10px] font-mono text-gray-600">disabled in demo mode</span>}
+      </div>
+    </div>
+  );
+}
+
+// ── Run list ──────────────────────────────────────────────────────────────────
+
+function RunList({
+  runs, selectedId, onSelect, loading,
+}: {
+  runs: { id: string; params: { coin: string; interval: string }; status: BacktestRunStatus; started_at: string }[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="card overflow-hidden">
+      <div className="px-4 pt-3 pb-2 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-indigo-400 text-base">📜</span>
+          <p className="label-muted">Runs</p>
+        </div>
+        <span className="text-xs font-mono text-gray-600">{loading ? 'Loading…' : `${runs.length}`}</span>
+      </div>
+      {runs.length === 0 ? (
+        <div className="flex items-center justify-center h-24 text-gray-600 text-sm">
+          {loading ? 'Loading runs…' : 'No runs yet — launch one above.'}
+        </div>
+      ) : (
+        <div className="divide-y divide-[#1e1e32] max-h-72 overflow-y-auto">
+          {runs.map(r => (
+            <button
+              key={r.id}
+              onClick={() => onSelect(r.id)}
+              className={[
+                'w-full text-left px-4 py-2.5 flex items-center justify-between gap-3 transition-colors',
+                selectedId === r.id ? 'bg-[#1a1a2e]' : 'hover:bg-[#161626]',
+              ].join(' ')}
+            >
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="text-xs font-mono text-gray-300">
+                  {r.params.coin} <span className="text-gray-600">{r.params.interval}</span>
+                </span>
+                <span className="text-[10px] font-mono text-gray-600">{fmtTs(r.started_at)}</span>
+              </div>
+              <StatusBadge status={r.status} />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Equity curve ──────────────────────────────────────────────────────────────
+
+function EquityCurve({ equity, starting }: { equity: { ts: string; equity: string }[]; starting: number }) {
+  const data = useMemo(
+    () => equity.map(p => ({ t: new Date(p.ts).getTime(), equity: parseFloat(p.equity) })),
+    [equity],
+  );
+  if (data.length === 0) {
+    return <div className="flex items-center justify-center h-40 text-gray-600 text-sm">No equity samples.</div>;
+  }
+  return (
+    <div className="h-64 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 8, right: 12, bottom: 4, left: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#1e1e32" />
+          <XAxis
+            dataKey="t" type="number" domain={['dataMin', 'dataMax']} scale="time"
+            tickFormatter={(t) => new Date(t).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })}
+            tick={{ fill: '#6b7280', fontSize: 10, fontFamily: 'monospace' }}
+            stroke="#1e1e32"
+          />
+          <YAxis
+            domain={['auto', 'auto']}
+            tick={{ fill: '#6b7280', fontSize: 10, fontFamily: 'monospace' }}
+            stroke="#1e1e32"
+            width={56}
+            tickFormatter={(v) => `$${Number(v).toFixed(0)}`}
+          />
+          <Tooltip
+            contentStyle={{ background: '#13131f', border: '1px solid #2e2e4e', borderRadius: 8, fontFamily: 'monospace', fontSize: 11 }}
+            labelFormatter={(t) => fmtTs(new Date(t as number).toISOString())}
+            formatter={(v: number | string) => [`$${Number(v).toFixed(2)}`, 'Equity']}
+          />
+          <ReferenceLine y={starting} stroke="#4b5563" strokeDasharray="4 4" />
+          <Line type="monotone" dataKey="equity" stroke="#818cf8" strokeWidth={1.6} dot={false} isAnimationActive={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ── Trades table ──────────────────────────────────────────────────────────────
+
+function TradesTable({ trades }: { trades: BacktestTrade[] }) {
+  if (trades.length === 0) {
+    return <div className="text-xs font-mono text-gray-600 px-4 py-3">No trades fired over this window.</div>;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs font-mono">
+        <thead>
+          <tr className="border-b border-[#1e1e32]">
+            {['Strategy', 'Side', 'Kind', 'Entry', 'Exit', 'Shares', 'P&L', 'Reason'].map(h => (
+              <th key={h} className="px-3 py-2 text-left text-gray-500 font-normal whitespace-nowrap">{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {trades.map((t, i) => {
+            const isYes = t.side.toUpperCase() === 'YES';
+            return (
+              <tr key={i} className="border-b border-[#1e1e32] hover:bg-[#1a1a2e] transition-colors">
+                <td className="px-3 py-2 text-gray-300 whitespace-nowrap">{t.strategy}</td>
+                <td className={`px-3 py-2 font-semibold ${isYes ? 'text-green-400' : 'text-red-400'}`}>{t.side}</td>
+                <td className="px-3 py-2 text-gray-500">{t.kind}</td>
+                <td className="px-3 py-2 text-gray-300">{fmtNum(t.entry_price, 4)}</td>
+                <td className="px-3 py-2 text-gray-300">{fmtNum(t.exit_price, 4)}</td>
+                <td className="px-3 py-2 text-gray-400">{fmtNum(t.shares, 2)}</td>
+                <td className={`px-3 py-2 font-semibold ${pnlClass(t.pnl)}`}>{fmtNum(t.pnl, 4)}</td>
+                <td className="px-3 py-2 text-gray-500 max-w-[220px] truncate" title={t.reason}>{t.reason}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Results view ──────────────────────────────────────────────────────────────
+
+function Results({ id }: { id: string }) {
+  const { data: run, error } = useSWR(
+    ['backtest-run', id],
+    () => getBacktestRun(id),
+    { refreshInterval: (d) => (d?.status === 'running' ? 2000 : 0) },
+  );
+
+  if (error) {
+    return <div className="card px-5 py-4 text-sm font-mono text-red-400">Failed to load run: {String(error)}</div>;
+  }
+  if (!run) {
+    return <div className="card px-5 py-4 text-sm text-gray-600">Loading run…</div>;
+  }
+
+  if (run.status === 'running') {
+    return (
+      <div className="card px-5 py-6 flex flex-col items-center justify-center gap-2">
+        <span className="h-2.5 w-2.5 rounded-full bg-amber-400 animate-pulse" />
+        <p className="text-sm font-mono text-amber-300">Replaying {run.params.coin} {run.params.interval}…</p>
+        <p className="text-[11px] font-mono text-gray-600">Fetching candles + funding, driving the real vipers.</p>
+      </div>
+    );
+  }
+
+  if (run.status === 'failed') {
+    return (
+      <div className="card px-5 py-4 space-y-2">
+        <div className="flex items-center gap-2"><StatusBadge status="failed" /><span className="text-sm font-mono text-gray-300">{run.params.coin} {run.params.interval}</span></div>
+        <div className="text-xs font-mono text-red-400 bg-red-500/10 border border-red-500/20 rounded px-3 py-2 whitespace-pre-wrap">
+          {run.error ?? 'unknown error'}
+        </div>
+      </div>
+    );
+  }
+
+  const report = run.report;
+  if (!report) {
+    return <div className="card px-5 py-4 text-sm text-gray-600">Run complete, but no report was attached.</div>;
+  }
+
+  const nl = report.native_ledger;
+  const rs = report.rs_backtester;
+  const scores = report.llm_scores ?? [];
+  const starting = parseFloat(nl.starting_collateral);
+
+  return (
+    <div className="space-y-5">
+      {/* Header / meta */}
+      <div className="card px-5 py-4 border border-indigo-500/20 bg-[#0d0d1a]">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <div className="flex items-center gap-2">
+            <StatusBadge status="done" />
+            <span className="text-sm font-mono text-gray-200">{report.coin} {report.interval}</span>
+          </div>
+          <span className="text-xs font-mono text-gray-500">
+            {report.ticks} ticks · {report.markets} synthetic hourly markets
+          </span>
+          <span className="text-xs font-mono text-gray-600">
+            replayed {fmtMs(report.replayed_start_ms)} → {fmtMs(report.replayed_end_ms)}
+          </span>
+          <span className="text-xs font-mono text-gray-600">
+            spread ±{report.params.spread} · depth {report.params.depth} · commission {report.params.commission}
+          </span>
+        </div>
+      </div>
+
+      {/* Native ledger headline */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="card px-4 py-3 flex flex-col gap-1">
+          <span className="label-muted">Starting</span>
+          <span className="stat-value text-gray-200">${fmtNum(nl.starting_collateral)}</span>
+        </div>
+        <div className="card px-4 py-3 flex flex-col gap-1">
+          <span className="label-muted">Realized P&L</span>
+          <span className={`stat-value ${pnlClass(nl.realized_pnl)}`}>{parseFloat(nl.realized_pnl) >= 0 ? '+' : ''}${fmtNum(nl.realized_pnl)}</span>
+        </div>
+        <div className="card px-4 py-3 flex flex-col gap-1">
+          <span className="label-muted">Final Equity</span>
+          <span className="stat-value text-gray-200">${fmtNum(nl.final_equity)}</span>
+        </div>
+        <div className="card px-4 py-3 flex flex-col gap-1">
+          <span className="label-muted">Closed Trades</span>
+          <span className="stat-value text-gray-200">{nl.closed_trades}</span>
+        </div>
+      </div>
+
+      {/* Equity curve */}
+      <div className="card px-4 py-3">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-indigo-400 text-base">📈</span>
+          <p className="label-muted">Equity Curve — Native Decimal Ledger</p>
+        </div>
+        <EquityCurve equity={run.equity ?? []} starting={starting} />
+      </div>
+
+      {/* Per-strategy metrics (native ledger) */}
+      <div className="card overflow-hidden">
+        <div className="px-4 pt-3 pb-2 flex items-center gap-2">
+          <span className="text-green-400 text-base">📒</span>
+          <p className="label-muted">Per-Strategy — Native Decimal Ledger (authoritative binary settlement)</p>
+        </div>
+        {nl.per_strategy.length === 0 ? (
+          <div className="text-xs font-mono text-gray-600 px-4 py-3">No trades fired — all vipers stood down.</div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs font-mono">
+              <thead>
+                <tr className="border-b border-[#1e1e32]">
+                  {['Strategy', 'Trades', 'Wins', 'Win %', 'P&L ($)'].map(h => (
+                    <th key={h} className="px-3 py-2 text-left text-gray-500 font-normal whitespace-nowrap">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {nl.per_strategy.map(s => (
+                  <tr key={s.strategy} className="border-b border-[#1e1e32] hover:bg-[#1a1a2e] transition-colors">
+                    <td className="px-3 py-2 text-gray-300">{s.strategy}</td>
+                    <td className="px-3 py-2 text-gray-400">{s.trades}</td>
+                    <td className="px-3 py-2 text-gray-400">{s.wins}</td>
+                    <td className="px-3 py-2 text-gray-400">{fmtPct(s.win_rate_pct, 1)}</td>
+                    <td className={`px-3 py-2 font-semibold ${pnlClass(s.pnl)}`}>{fmtNum(s.pnl, 2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* rs-backtester proxy metrics */}
+      <div className="card px-4 py-3">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-amber-400 text-base">📐</span>
+          <p className="label-muted">rs-backtester — Directional Proxy on the Underlying (NOT the binary payoff)</p>
+        </div>
+        {rs ? (
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 text-xs font-mono">
+            <div className="flex flex-col gap-0.5"><span className="text-gray-500">Return</span><span className={pnlClass(rs.return_pct)}>{fmtPct(rs.return_pct)}</span></div>
+            <div className="flex flex-col gap-0.5"><span className="text-gray-500">Sharpe</span><span className="text-gray-300">{fmtNum(rs.sharpe, 2)}</span></div>
+            <div className="flex flex-col gap-0.5"><span className="text-gray-500">Max DD</span><span className="text-gray-300">{fmtPct(rs.max_drawdown_pct)}</span></div>
+            <div className="flex flex-col gap-0.5"><span className="text-gray-500">Win Rate</span><span className="text-gray-300">{fmtPct(rs.win_rate_pct)}</span></div>
+            <div className="flex flex-col gap-0.5"><span className="text-gray-500">Trades</span><span className="text-gray-300">{rs.trades_nr ?? '—'}</span></div>
+          </div>
+        ) : (
+          <div className="text-xs font-mono text-gray-600">Proxy skipped (series too short or crate declined the data).</div>
+        )}
+      </div>
+
+      {/* LLM scores */}
+      {scores.length > 0 && (
+        <div className="card overflow-hidden">
+          <div className="px-4 pt-3 pb-2 flex items-center gap-2">
+            <span className="text-violet-400 text-base">🤖</span>
+            <p className="label-muted">LLM Conviction — Score vs Realized Outcome</p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs font-mono">
+              <thead>
+                <tr className="border-b border-[#1e1e32]">
+                  {['Strategy', 'Side', 'Entry', 'Score', 'Realized P&L', 'Rationale'].map(h => (
+                    <th key={h} className="px-3 py-2 text-left text-gray-500 font-normal whitespace-nowrap">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {scores.map((s, i) => (
+                  <tr key={i} className="border-b border-[#1e1e32] hover:bg-[#1a1a2e] transition-colors">
+                    <td className="px-3 py-2 text-gray-300">{s.strategy}</td>
+                    <td className={`px-3 py-2 font-semibold ${s.side.toUpperCase() === 'YES' ? 'text-green-400' : 'text-red-400'}`}>{s.side}</td>
+                    <td className="px-3 py-2 text-gray-500">{fmtTs(s.entry_ts)}</td>
+                    <td className="px-3 py-2 text-violet-300">{s.score}/100</td>
+                    <td className={`px-3 py-2 font-semibold ${pnlClass(s.realized_pnl)}`}>{s.realized_pnl === null ? '—' : fmtNum(s.realized_pnl, 4)}</td>
+                    <td className="px-3 py-2 text-gray-500 max-w-[280px] truncate" title={s.rationale}>{s.rationale}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Trades */}
+      <div className="card overflow-hidden">
+        <div className="px-4 pt-3 pb-2 flex items-center gap-2">
+          <span className="text-indigo-400 text-base">🎯</span>
+          <p className="label-muted">Trades</p>
+        </div>
+        <TradesTable trades={run.trades ?? []} />
+      </div>
+
+      {/* Fidelity disclaimer — prominent, verbatim from report.json */}
+      <div className="card px-4 py-3 border border-amber-500/20 bg-amber-500/[0.03]">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-amber-400 text-base">⚠️</span>
+          <p className="label-muted text-amber-300/80">Fidelity Tiers — Read Before Trusting These Numbers</p>
+        </div>
+        <pre className="text-[11px] font-mono text-amber-200/80 whitespace-pre-wrap leading-relaxed overflow-x-auto">
+          {report.fidelity}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+interface Props {
+  availableAssets: string[];
+}
+
+export default function BacktestPage({ availableAssets }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const { data: runs = [], isLoading, mutate } = useSWR(
+    'backtest-runs',
+    getBacktestRuns,
+    { refreshInterval: (d) => (d?.some(r => r.status === 'running') ? 2000 : 15000) },
+  );
+
+  const busy = runs.some(r => r.status === 'running');
+
+  async function handleRun(req: BacktestRunRequest) {
+    const { id } = await runBacktest(req);
+    await mutate();
+    setSelectedId(id);
+  }
+
+  // Default the results pane to the newest run once runs load.
+  const effectiveId = selectedId ?? (runs.length > 0 ? runs[0].id : null);
+
+  return (
+    <div className="space-y-5">
+      <div className="card px-5 py-4 border border-indigo-500/20 bg-[#0d0d1a]">
+        <p className="label-muted text-xs">🧪 Backtest — Historical Viper Replay</p>
+        <p className="text-sm text-gray-400 mt-0.5">
+          Replays historical Hyperliquid candles through the real viper strategies with an
+          authoritative Decimal ledger and an rs-backtester directional proxy.
+          <span className="text-gray-500"> Two labeled PnL views; honest fidelity tiers on every result.</span>
+        </p>
+      </div>
+
+      <RunForm assets={availableAssets} busy={busy} onRun={handleRun} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,20rem)_1fr] gap-5 items-start">
+        <RunList runs={runs} selectedId={effectiveId} onSelect={setSelectedId} loading={isLoading} />
+        <div className="min-w-0">
+          {effectiveId
+            ? <Results id={effectiveId} />
+            : <div className="card px-5 py-8 text-center text-sm text-gray-600">Launch a run to see results here.</div>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/control-tower/src/components/LlmAdvisorCard.tsx
+++ b/control-tower/src/components/LlmAdvisorCard.tsx
@@ -7,6 +7,10 @@ interface Props {
   recommendations: LlmRecommendationRow[];
   isLoading: boolean;
   advisorEnabled: boolean;
+  /** Effective advisor provider (GET /api/status.llm_provider). */
+  llmProvider?: string;
+  /** Effective advisor model tag (GET /api/status.llm_model). */
+  llmModel?: string;
 }
 
 /** Format an ISO timestamp to a short local string, e.g. "May 11, 14:32" */
@@ -22,7 +26,7 @@ function fmtTs(iso: string): string {
   }
 }
 
-export default function LlmAdvisorCard({ recommendations, isLoading, advisorEnabled }: Props) {
+export default function LlmAdvisorCard({ recommendations, isLoading, advisorEnabled, llmProvider, llmModel }: Props) {
   const [idx, setIdx] = useState(0);
   const [dismissed, setDismissed] = useState<Set<number>>(new Set());
   const [expanded, setExpanded] = useState(false);
@@ -52,6 +56,14 @@ export default function LlmAdvisorCard({ recommendations, isLoading, advisorEnab
         <div className="flex items-center gap-2">
           <p className="label-muted">LLM Advisor</p>
           <span className="text-xs font-mono text-gray-600">🤖</span>
+          {llmProvider && (
+            <span
+              className="text-[10px] font-mono bg-violet-500/10 text-violet-300 border border-violet-500/20 rounded px-1.5 py-0.5"
+              title="Effective LLM Advisor provider/model (resolved server-side; no key)"
+            >
+              {llmProvider}{llmModel ? ` · ${llmModel}` : ''}
+            </span>
+          )}
           {!advisorEnabled && (
             <span className="text-[10px] font-mono bg-gray-800 text-gray-500 border border-gray-700 rounded px-1.5 py-0.5">
               DISABLED

--- a/control-tower/src/components/SquadronDetailView.tsx
+++ b/control-tower/src/components/SquadronDetailView.tsx
@@ -41,16 +41,36 @@ const RAPTOR_META: Record<
   },
 };
 
+/** Per-raptor source labels when MARKET_DATA_SOURCE=hyperliquid. The Tide Raptor
+ *  is source-independent (Alpaca/iNAV) so it keeps its RAPTOR_META source. */
+const HYPERLIQUID_SOURCE: Record<string, string> = {
+  price:       'Hyperliquid Trades WS',
+  funding:     'Hyperliquid Funding (assetCtx)',
+  derivatives: 'Hyperliquid OI + CVD',
+};
+
+/** Resolve the human-readable source label for a raptor kind, parameterized by
+ *  the active market-data source. Falls back to the Binance RAPTOR_META label
+ *  when the source is absent (older backend) or not hyperliquid. */
+function raptorSource(kind: string, marketDataSource?: string): string | undefined {
+  if (marketDataSource === 'hyperliquid' && HYPERLIQUID_SOURCE[kind]) {
+    return HYPERLIQUID_SOURCE[kind];
+  }
+  return RAPTOR_META[kind]?.source;
+}
+
 function RaptorHealthPanel({
   raptorKinds,
   raptors,
   asset,
   marketClass,
+  marketDataSource,
 }: {
   raptorKinds: string[];
   raptors?: Record<string, AssetRaptorHealth>;
   asset: string;
   marketClass: string;
+  marketDataSource?: string;
 }) {
   const h = raptors?.[asset];
 
@@ -103,7 +123,7 @@ function RaptorHealthPanel({
             );
           })}
           {(() => {
-            const sources = raptorKinds.map((k) => RAPTOR_META[k]?.source).filter(Boolean);
+            const sources = raptorKinds.map((k) => raptorSource(k, marketDataSource)).filter(Boolean);
             return sources.length > 0 ? (
               <div className="text-[10px] font-mono text-gray-600 pt-1">
                 Source: {sources.join(' + ')}
@@ -257,6 +277,7 @@ export default function SquadronDetailView({ squadron, onBack }: Props) {
           raptors={status?.raptors}
           asset={asset}
           marketClass={marketClass}
+          marketDataSource={status?.market_data_source}
         />
       </div>
 

--- a/control-tower/src/components/TelemetryPage.tsx
+++ b/control-tower/src/components/TelemetryPage.tsx
@@ -6,7 +6,7 @@ import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
   ReferenceLine, Brush,
 } from 'recharts';
-import { getTelemetryHistory } from '@/lib/api';
+import { getTelemetryHistory, getStatus } from '@/lib/api';
 import type { TelemetrySample } from '@/lib/types';
 
 const POLL_MS = 2000;            // server samples at 2s — match it while live
@@ -406,6 +406,15 @@ export default function TelemetryPage({ availableAssets }: { availableAssets: st
     { refreshInterval: live ? POLL_MS : 0, revalidateOnFocus: false, keepPreviousData: true },
   );
 
+  // Active market-data source drives the signal-chart subtitles (Binance vs
+  // Hyperliquid). Absent field (older backend) → Binance labels.
+  const { data: status } = useSWR('status', getStatus, { refreshInterval: 30_000 });
+  const isHyperliquid = status?.market_data_source === 'hyperliquid';
+  const srcName = isHyperliquid ? 'Hyperliquid' : 'Binance';
+  const oracleSubtitle = isHyperliquid ? 'Hyperliquid trades — current mark' : 'Binance Spot WS — current mark';
+  const fundingSubtitle = `${srcName} perpetual — smart-money lean`;
+  const oiSubtitle = `${srcName} perp OI change — 10m regime pressure`;
+
   const rows = useMemo<Row[]>(() => (samples ?? []).map(toRow), [samples]);
 
   // When pausing, seed the scrub range to the full loaded window; clear on resume.
@@ -451,6 +460,22 @@ export default function TelemetryPage({ availableAssets }: { availableAssets: st
           <ConnPill label="Derivatives Raptor" live={!!lastSample?.deriv_connected} />
           {asset === 'btc' && (
             <ConnPill label="Tide Raptor" live={!!lastSample?.tide_connected} />
+          )}
+
+          {/* Market-data source + effective LLM advisor provider/model. */}
+          <span
+            className="text-[10px] font-mono bg-sky-500/10 text-sky-300 border border-sky-500/20 rounded px-1.5 py-0.5"
+            title="Active market-data source"
+          >
+            src · {srcName}
+          </span>
+          {status?.llm_provider && (
+            <span
+              className="text-[10px] font-mono bg-violet-500/10 text-violet-300 border border-violet-500/20 rounded px-1.5 py-0.5"
+              title="Effective LLM Advisor provider/model (resolved server-side; no key)"
+            >
+              🤖 {status.llm_provider}{status.llm_model ? ` · ${status.llm_model}` : ''}
+            </span>
           )}
 
           {/* Window selector */}
@@ -530,7 +555,7 @@ export default function TelemetryPage({ availableAssets }: { availableAssets: st
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <SignalChart
           title="Oracle Price"
-          subtitle="Binance Spot WS — current mark"
+          subtitle={oracleSubtitle}
           data={viewRows}
           series={[{ key: 'oracle', label: 'price', color: '#10b981' }]}
           fmtY={v => `$${Math.round(v).toLocaleString('en-US')}`}
@@ -560,7 +585,7 @@ export default function TelemetryPage({ availableAssets }: { availableAssets: st
         />
         <SignalChart
           title="Funding Rate"
-          subtitle="Binance perpetual — smart-money lean"
+          subtitle={fundingSubtitle}
           data={viewRows}
           zeroLine
           series={[{ key: 'funding', label: 'rate', color: '#14b8a6' }]}
@@ -568,7 +593,7 @@ export default function TelemetryPage({ availableAssets }: { availableAssets: st
         />
         <SignalChart
           title="Open Interest Δ"
-          subtitle="Binance perp OI change — 10m regime pressure"
+          subtitle={oiSubtitle}
           data={viewRows}
           zeroLine
           series={[{ key: 'oiDelta', label: 'ΔOI', color: '#f97316' }]}

--- a/control-tower/src/components/TradelogPage.tsx
+++ b/control-tower/src/components/TradelogPage.tsx
@@ -101,7 +101,7 @@ function assetToEntries(asset: string, trades: TradeRow[], positions: OpenPositi
       shares:     parseFloat(t.shares),
       pnl:        parseFloat(t.pnl),
       reason:     t.reason,
-      ghost:      false,
+      ghost:      t.ghost_mode,
       chainAdopted: false,
     });
   }
@@ -270,6 +270,8 @@ export default function TradelogPage({ availableAssets }: Props) {
   const [statusFilter,   setStatusFilter]   = useState<string>('all');
   const [strategyFilter, setStrategyFilter] = useState<string>('all');
   const [sideFilter,     setSideFilter]     = useState<string>('all');
+  // Live vs Paper (ghost) segmented control — filters rows on their ghost flag.
+  const [modeFilter,     setModeFilter]     = useState<'all' | 'live' | 'paper'>('all');
 
   // ── RTB state ───────────────────────────────────────────────────────────────
   const [rtbEntry,   setRtbEntry]   = useState<LogEntry | null>(null);
@@ -338,9 +340,11 @@ export default function TradelogPage({ availableAssets }: Props) {
       if (statusFilter   !== 'all' && e.status                       !== statusFilter)   return false;
       if (strategyFilter !== 'all' && shortStrategy(e.strategy)      !== strategyFilter) return false;
       if (sideFilter     !== 'all' && e.side.toUpperCase()           !== sideFilter)     return false;
+      if (modeFilter     === 'live'  && e.ghost)  return false;
+      if (modeFilter     === 'paper' && !e.ghost) return false;
       return true;
     });
-  }, [allEntries, assetFilter, statusFilter, strategyFilter, sideFilter]);
+  }, [allEntries, assetFilter, statusFilter, strategyFilter, sideFilter, modeFilter]);
 
   // ── RTB handler ──────────────────────────────────────────────────────────────
   const handleRtbConfirm = async () => {
@@ -413,6 +417,16 @@ export default function TradelogPage({ availableAssets }: Props) {
           <span className="text-xs text-gray-500 font-mono ml-4 mr-1">Side:</span>
           {['all', 'YES', 'NO'].map(s => (
             <FilterPill key={s} label={s === 'all' ? 'All' : s} active={sideFilter === s} onClick={() => setSideFilter(s)} />
+          ))}
+
+          {/* Mode — Live vs Paper (ghost) */}
+          <span className="text-xs text-gray-500 font-mono ml-4 mr-1">Mode:</span>
+          {([
+            { v: 'all',   label: 'All' },
+            { v: 'live',  label: '⚡ Live' },
+            { v: 'paper', label: '👻 Paper' },
+          ] as const).map(({ v, label }) => (
+            <FilterPill key={v} label={label} active={modeFilter === v} onClick={() => setModeFilter(v)} />
           ))}
         </div>
         <div className="flex flex-wrap items-center gap-2">

--- a/control-tower/src/lib/api.ts
+++ b/control-tower/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { DynamicConfig, ConfigFieldSchema, PnlSnapshotRow, TradeRow, OpenPositionRow, LlmRecommendationRow, ViperDef, StatusResponse, PortfolioValue, SquadronSummary, TelemetrySnapshot, TelemetrySample } from './types';
+import type { DynamicConfig, ConfigFieldSchema, PnlSnapshotRow, TradeRow, OpenPositionRow, LlmRecommendationRow, ViperDef, StatusResponse, PortfolioValue, SquadronSummary, TelemetrySnapshot, TelemetrySample, BacktestRunSummary, BacktestRun, BacktestRunRequest } from './types';
 
 // In development, NEXT_PUBLIC_API_URL=http://localhost:9000 (set in .env.local)
 // hits the DRADIS API directly.
@@ -155,6 +155,62 @@ export async function patchSquadronConfig(squadronId: string, patch: Partial<Dyn
     cache: 'no-store',
   });
   if (!res.ok) throw new Error(`PATCH /api/squadrons/${squadronId}/config → ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+// ── Backtest (feature-gated backend) ─────────────────────────────────────────
+//
+// The backtest routes exist ONLY when the server was built with `--features
+// backtest`. On a default build they are absent (404). `probeBacktest` lets the
+// dashboard hide the Backtest tab entirely rather than surfacing dead UI.
+
+/** Probe whether the backtest API is present.
+ *
+ * Hide the Backtest tab ONLY when the routes are genuinely absent (404 on a
+ * default build). A transient failure — 503 while the engine restarts, a 401
+ * auth hiccup, or a network error — must NOT permanently hide the tab: the probe
+ * fires once per page session (refreshInterval 0), so conflating those with 404
+ * would keep the tab hidden until a full reload even after the engine recovers.
+ * On anything other than a definitive 404 we return true and let the tab's own
+ * data hooks surface errors / self-heal, exactly like every other tab. */
+export async function probeBacktest(): Promise<boolean> {
+  try {
+    const res = await fetch(`${BASE}/api/backtest/runs`, { cache: 'no-store', headers: buildHeaders() });
+    // 404 → feature-gated routes are absent → hide. Any other status (200, or a
+    // transient 5xx/401) → treat as present so a routine restart doesn't hide the tab.
+    return res.status !== 404;
+  } catch {
+    // Network error (engine unreachable mid-restart) → don't permanently hide; show.
+    return true;
+  }
+}
+
+export async function getBacktestRuns(): Promise<BacktestRunSummary[]> {
+  const res = await fetch(`${BASE}/api/backtest/runs`, { cache: 'no-store', headers: buildHeaders() });
+  if (!res.ok) throw new Error(`GET /api/backtest/runs → ${res.status}`);
+  return res.json();
+}
+
+export async function getBacktestRun(id: string): Promise<BacktestRun> {
+  const res = await fetch(`${BASE}/api/backtest/runs/${encodeURIComponent(id)}`, { cache: 'no-store', headers: buildHeaders() });
+  if (!res.ok) throw new Error(`GET /api/backtest/runs/${id} → ${res.status}`);
+  return res.json();
+}
+
+/** Start a backtest run. Returns `{ id, status }` on 202, or throws (409 while a
+ *  run is in progress, 400 on bad params) with the server's error text. */
+export async function runBacktest(body: BacktestRunRequest): Promise<{ id: string; status: string }> {
+  const res = await fetch(`${BASE}/api/backtest/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...buildHeaders() },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    let msg = `${res.status}`;
+    try { const j = await res.json(); if (j?.error) msg = j.error; } catch { /* non-JSON body */ }
+    throw new Error(msg);
+  }
   return res.json();
 }
 

--- a/control-tower/src/lib/types.ts
+++ b/control-tower/src/lib/types.ts
@@ -107,6 +107,7 @@ export interface TradeRow {
   shares:      string;
   pnl:         string;
   reason:      string;
+  ghost_mode:  boolean; // true when this trade closed a simulated (paper) position
 }
 
 /** A position that has been entered but not yet exited (all strategies, ghost+live). */
@@ -200,8 +201,22 @@ export interface StatusResponse {
   strategy_markets: Record<string, string>;
   /** RFC-3339 timestamp of the current bot session start (= process startup). */
   session_started_at?: string;
-  /** Per-asset Binance Raptor connection health. Key = asset symbol (e.g. "btc"). */
+  /** Per-asset Raptor connection health. Key = asset symbol (e.g. "btc"). */
   raptors?: Record<string, AssetRaptorHealth>;
+  /** Active market-data source ("binance" | "hyperliquid"). Absent on older
+   *  backends → treat as "binance". Drives the Raptor/telemetry source labels. */
+  market_data_source?: string;
+  /** Realized paper (ghost) session P&L across all squadrons (Decimal string).
+   *  Segregated from the live session P&L. Absent on older backends. */
+  paper_pnl?: string;
+  /** Simulated paper collateral balance across all squadrons (Decimal string). */
+  paper_balance?: string;
+  /** Effective LLM Advisor provider ("ollama" | "anthropic" | "openai" |
+   *  "openai-compatible" | "chatgpt"). Absent on older backends. Never a key. */
+  llm_provider?: string;
+  /** Effective LLM Advisor model tag (e.g. "llama3.2"). Empty when a cloud
+   *  provider is selected but no model is configured. Absent on older backends. */
+  llm_model?: string;
 }
 
 /** Portfolio value response from /api/portfolio — cash + open positions at live prices. */
@@ -212,6 +227,137 @@ export interface PortfolioValue {
   unrealized_pnl:  string; // Σ(shares × (current_mid − entry_price))
   position_count:  number;
   prices_live:     boolean; // false when Polymarket CLOB was unreachable
+}
+
+// ── Backtest types (feature-gated backend; `--features backtest`) ─────────────
+//
+// Mirrors src/api/backtest_api.rs + the report.json structure from
+// src/backtest/report.rs::build_report_json. Every Decimal arrives as a string.
+
+export type BacktestRunStatus = 'running' | 'done' | 'failed';
+
+/** Echo of the resolved run parameters (string-encoded Decimals). */
+export interface BacktestRunParams {
+  coin:        string;
+  interval:    string;
+  start_ms:    number;
+  end_ms:      number;
+  spread:      string;
+  depth:       string;
+  commission:  string;
+  starting:    string;
+  strategies:  string[] | null;
+  llm_score:   boolean;
+}
+
+/** Lightweight list entry — GET /api/backtest/runs. */
+export interface BacktestRunSummary {
+  id:          string;
+  params:      BacktestRunParams;
+  status:      BacktestRunStatus;
+  error:       string | null;
+  started_at:  string;
+  finished_at: string | null;
+}
+
+/** One equity-curve sample. */
+export interface BacktestEquityPoint {
+  ts:     string; // RFC-3339
+  equity: string; // Decimal string
+}
+
+/** One closed trade row. */
+export interface BacktestTrade {
+  strategy:    string;
+  side:        string;
+  kind:        string; // "Exit" | "Settlement"
+  entry_ts:    string;
+  exit_ts:     string;
+  entry_price: string;
+  exit_price:  string;
+  shares:      string;
+  pnl:         string;
+  reason:      string;
+}
+
+/** Per-strategy native-ledger roll-up (report.native_ledger.per_strategy[]). */
+export interface BacktestStrategyStat {
+  strategy:     string;
+  trades:       number;
+  wins:         number;
+  win_rate_pct: number;
+  pnl:          string; // Decimal string
+}
+
+/** rs-backtester directional-proxy metrics (report.rs_backtester; null if skipped). */
+export interface BacktestRsMetrics {
+  note:             string;
+  return_pct:       number | null;
+  sharpe:           number | null;
+  max_drawdown_pct: number | null;
+  win_rate_pct:     number | null;
+  trades_nr:        number | null;
+}
+
+/** One LLM decision score (report.llm_scores[]). */
+export interface BacktestLlmScore {
+  strategy:     string;
+  side:         string;
+  entry_ts:     string;
+  score:        number;
+  rationale:    string;
+  realized_pnl: string | null;
+}
+
+/** The report.json document (report.rs::build_report_json). */
+export interface BacktestReport {
+  coin:              string;
+  interval:          string;
+  start_ms:          number;
+  end_ms:            number;
+  replayed_start_ms: number | null;
+  replayed_end_ms:   number | null;
+  ticks:             number;
+  markets:           number;
+  params: {
+    spread:     string;
+    depth:      string;
+    commission: string;
+    strategies: string[] | null;
+    llm_score:  boolean;
+  };
+  native_ledger: {
+    note:                string;
+    starting_collateral: string;
+    realized_pnl:        string;
+    final_equity:        string;
+    closed_trades:       number;
+    per_strategy:        BacktestStrategyStat[];
+  };
+  rs_backtester: BacktestRsMetrics | null;
+  llm_scores:    BacktestLlmScore[];
+  fidelity:      string;
+}
+
+/** Full run record — GET /api/backtest/runs/{id}. */
+export interface BacktestRun extends BacktestRunSummary {
+  report: BacktestReport | null;
+  equity: BacktestEquityPoint[] | null;
+  trades: BacktestTrade[] | null;
+}
+
+/** POST /api/backtest/run body — mirrors the CLI args. */
+export interface BacktestRunRequest {
+  coin:        string;
+  start:       string;
+  end:         string;
+  interval?:   string;
+  spread?:     string;
+  depth?:      string;
+  commission?: string;
+  starting?:   string;
+  strategies?: string[];
+  llm_score?:  boolean;
 }
 
 // ── Squadron / CAG types (Phase 3d) ──────────────────────────────────────────

--- a/docs/CUSTOM_STRATEGY.md
+++ b/docs/CUSTOM_STRATEGY.md
@@ -8,7 +8,7 @@ This guide walks through implementing and integrating a new trading strategy int
 
 Every 50ms the main loop:
 
-1. Reads the latest `MarketSnapshot` (Polymarket prices + Binance oracle data).
+1. Reads the latest `MarketSnapshot` (Polymarket prices + oracle data from the configured market-data source).
 2. Builds a `StrategyContext` containing everything needed to make a decision.
 3. Calls `execute_strategies_concurrent()` — runs **all** strategies' `evaluate_exit()` and `evaluate_entry()` concurrently.
 4. Collects the returned `StrategySignal` (which now contains full `OrderParams`).

--- a/src/api/backtest_api.rs
+++ b/src/api/backtest_api.rs
@@ -1,0 +1,601 @@
+//! Feature-gated (`--features backtest`) Control Tower backtest API.
+//!
+//! An in-memory run registry plus three endpoints:
+//!   POST /api/backtest/run        — spawn ONE run (409 while one is in progress)
+//!   GET  /api/backtest/runs       — list runs, newest first (lightweight summaries)
+//!   GET  /api/backtest/runs/{id}  — full report + equity + trades + llm scores
+//!
+//! rs-backtester's process-global CONFIG makes concurrent runs unsafe (documented in
+//! BACKTEST-RECON.md), so the registry admits exactly ONE running job at a time.
+//!
+//! The whole module — and every field/route it adds to the server — is compiled ONLY
+//! under `--features backtest`, so the default build is byte-identical.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{bail, Context};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use rust_decimal::prelude::FromStr;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::api::server::ApiState;
+use crate::backtest::entry::{parse_time, run_and_collect, EquityPoint, TradeRecord};
+use crate::backtest::harness::BacktestConfig;
+
+/// Default backtest cache — the CLI default; a SEPARATE sqlite file from the live DB.
+const DEFAULT_CACHE_PATH: &str = "backtest_cache.sqlite";
+
+/// Cap on retained registry entries. The registry lives in the LIVE process's
+/// `ApiState` for its whole lifetime and each completed run holds a full
+/// report + equity curve + trades payload, so without a bound repeated runs are a
+/// monotonic RSS leak. We keep the most recent `MAX_RUNS`, evicting the oldest
+/// FINISHED entries (never the in-flight run).
+const MAX_RUNS: usize = 50;
+
+// ── Registry types ─────────────────────────────────────────────────────────────
+
+/// Lifecycle of one registry entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RunStatus {
+    Running,
+    Done,
+    Failed,
+}
+
+/// Echo of the resolved run parameters (string-encoded Decimals; no key material).
+#[derive(Debug, Clone, Serialize)]
+pub struct RunParamsEcho {
+    pub coin: String,
+    pub interval: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub spread: String,
+    pub depth: String,
+    pub commission: String,
+    pub starting: String,
+    pub strategies: Option<Vec<String>>,
+    pub llm_score: bool,
+}
+
+/// One registry entry — the full record served by `GET /api/backtest/runs/{id}`.
+#[derive(Debug, Clone, Serialize)]
+pub struct BacktestRun {
+    pub id: String,
+    pub params: RunParamsEcho,
+    pub status: RunStatus,
+    pub error: Option<String>,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    /// Report JSON (identical structure to report.json) — populated on completion.
+    pub report: Option<serde_json::Value>,
+    pub equity: Option<Vec<EquityPoint>>,
+    pub trades: Option<Vec<TradeRecord>>,
+}
+
+/// Lightweight list view — omits the heavy report/equity/trades payload.
+#[derive(Debug, Clone, Serialize)]
+pub struct RunSummary {
+    pub id: String,
+    pub params: RunParamsEcho,
+    pub status: RunStatus,
+    pub error: Option<String>,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+}
+
+impl RunSummary {
+    fn from_run(r: &BacktestRun) -> Self {
+        Self {
+            id: r.id.clone(),
+            params: r.params.clone(),
+            status: r.status,
+            error: r.error.clone(),
+            started_at: r.started_at.clone(),
+            finished_at: r.finished_at.clone(),
+        }
+    }
+}
+
+/// Shared in-memory registry — an `Arc<Mutex<..>>` field in `ApiState`.
+#[derive(Clone, Default)]
+pub struct BacktestRegistry {
+    inner: Arc<Mutex<Vec<BacktestRun>>>,
+}
+
+impl BacktestRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<BacktestRun>> {
+        match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        }
+    }
+
+    /// True while any run is still `Running`. Retained for the registry unit tests;
+    /// the handler admits runs via the atomic [`try_begin`](Self::try_begin) instead.
+    #[cfg(test)]
+    fn is_busy(&self) -> bool {
+        self.lock().iter().any(|r| r.status == RunStatus::Running)
+    }
+
+    /// Unconditional push (test helper — seeds multiple entries without the one-at-a-time
+    /// admission that [`try_begin`](Self::try_begin) enforces).
+    #[cfg(test)]
+    fn insert(&self, run: BacktestRun) {
+        let mut g = self.lock();
+        g.push(run);
+        Self::prune(&mut g);
+    }
+
+    /// Atomically admit ONE run: under a single `MutexGuard`, reject if a run is
+    /// already `Running`, otherwise push the new entry. This closes the check-then-act
+    /// race in the old `is_busy()` + `insert()` split (two independent lock scopes let
+    /// concurrent POSTs both pass the guard and spawn overlapping runs that corrupt
+    /// rs-backtester's process-global CONFIG). Returns `false` when a run is in progress.
+    #[must_use]
+    fn try_begin(&self, run: BacktestRun) -> bool {
+        let mut g = self.lock();
+        if g.iter().any(|r| r.status == RunStatus::Running) {
+            return false;
+        }
+        g.push(run);
+        Self::prune(&mut g);
+        true
+    }
+
+    /// Evict the oldest FINISHED entries until at most `MAX_RUNS` remain. A `Running`
+    /// entry is never evicted (skipped), so the in-flight run's payload is always kept.
+    fn prune(g: &mut Vec<BacktestRun>) {
+        while g.len() > MAX_RUNS {
+            match g.iter().position(|r| r.status != RunStatus::Running) {
+                Some(pos) => {
+                    g.remove(pos);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Transition a run to `Done` and attach its collected payload.
+    fn complete(
+        &self,
+        id: &str,
+        report: serde_json::Value,
+        equity: Vec<EquityPoint>,
+        trades: Vec<TradeRecord>,
+    ) {
+        let mut g = self.lock();
+        if let Some(r) = g.iter_mut().find(|r| r.id == id) {
+            r.status = RunStatus::Done;
+            r.finished_at = Some(now_rfc3339());
+            r.report = Some(report);
+            r.equity = Some(equity);
+            r.trades = Some(trades);
+        }
+    }
+
+    /// Transition a run to `Failed` with an error message (never key material).
+    fn fail(&self, id: &str, err: String) {
+        let mut g = self.lock();
+        if let Some(r) = g.iter_mut().find(|r| r.id == id) {
+            r.status = RunStatus::Failed;
+            r.finished_at = Some(now_rfc3339());
+            r.error = Some(err);
+        }
+    }
+
+    fn summaries_newest_first(&self) -> Vec<RunSummary> {
+        self.lock().iter().rev().map(RunSummary::from_run).collect()
+    }
+
+    fn get(&self, id: &str) -> Option<BacktestRun> {
+        self.lock().iter().find(|r| r.id == id).cloned()
+    }
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+static RUN_SEQ: AtomicU64 = AtomicU64::new(1);
+
+fn new_run_id() -> String {
+    let seq = RUN_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("bt-{}-{}", chrono::Utc::now().timestamp_millis(), seq)
+}
+
+// ── Request body ─────────────────────────────────────────────────────────────
+
+/// POST /api/backtest/run body — mirrors the CLI args. Numeric knobs are strings so
+/// they round-trip exactly as Decimals (consistent with the rest of the API).
+#[derive(Debug, Deserialize)]
+pub struct RunRequest {
+    pub coin: String,
+    pub start: String,
+    pub end: String,
+    #[serde(default)]
+    pub interval: Option<String>,
+    #[serde(default)]
+    pub spread: Option<String>,
+    #[serde(default)]
+    pub depth: Option<String>,
+    #[serde(default)]
+    pub commission: Option<String>,
+    #[serde(default)]
+    pub starting: Option<String>,
+    #[serde(default)]
+    pub strategies: Option<Vec<String>>,
+    #[serde(default)]
+    pub llm_score: Option<bool>,
+}
+
+/// Parse an optional Decimal knob, falling back to `default` when empty/absent.
+fn parse_dec(v: Option<&str>, default: &str, field: &str) -> anyhow::Result<Decimal> {
+    let s = v.map(|s| s.trim()).filter(|s| !s.is_empty()).unwrap_or(default);
+    Decimal::from_str(s).with_context(|| format!("invalid {field}: {s}"))
+}
+
+/// Resolve a request into a fully-validated `BacktestConfig`, applying the same
+/// defaults as the CLI. The cache path is the CLI default (a separate sqlite file);
+/// `out_dir` is unused because the API keeps results in the registry, never on disk.
+fn build_config(req: &RunRequest) -> anyhow::Result<BacktestConfig> {
+    let coin = req.coin.trim();
+    if coin.is_empty() {
+        bail!("coin is required (e.g. \"BTC\")");
+    }
+    let coin = coin.to_uppercase();
+    let start_ms = parse_time(&req.start).context("start")?;
+    let end_ms = parse_time(&req.end).context("end")?;
+    if end_ms <= start_ms {
+        bail!("end ({end_ms}) must be after start ({start_ms})");
+    }
+    let interval = req
+        .interval
+        .clone()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "1m".to_string());
+    let half_spread = parse_dec(req.spread.as_deref(), "0.02", "spread")?;
+    let depth = parse_dec(req.depth.as_deref(), "500", "depth")?;
+    let commission = parse_dec(req.commission.as_deref(), "0", "commission")?;
+    let starting = parse_dec(req.starting.as_deref(), "500", "starting")?;
+
+    // Range-check the numeric knobs. Prediction-market prices live in [0.01, 0.99], so a
+    // negative half-spread would synthesize a CROSSED book (ask < bid) that banks phantom
+    // profit on every round-trip, silently corrupting the "authoritative" ledger; guard it
+    // (and the other physically-meaningless values) here since the harness does not.
+    let half = Decimal::from_str("0.5").unwrap();
+    let one = Decimal::from_str("1").unwrap();
+    if half_spread < Decimal::ZERO || half_spread > half {
+        bail!("spread (book half-spread) must be between 0 and 0.5, got {half_spread}");
+    }
+    if depth <= Decimal::ZERO {
+        bail!("depth must be a positive number of shares, got {depth}");
+    }
+    if commission < Decimal::ZERO || commission >= one {
+        bail!("commission rate must be in [0, 1), got {commission}");
+    }
+    if starting <= Decimal::ZERO {
+        bail!("starting collateral must be positive, got {starting}");
+    }
+    let strategies = req
+        .strategies
+        .clone()
+        .map(|v| {
+            v.into_iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .filter(|v| !v.is_empty());
+
+    Ok(BacktestConfig {
+        crypto_filter: coin.to_lowercase(),
+        coin,
+        interval,
+        start_ms,
+        end_ms,
+        strategies,
+        half_spread,
+        depth,
+        commission,
+        starting_collateral: starting,
+        llm_score: req.llm_score.unwrap_or(false),
+        cache_path: DEFAULT_CACHE_PATH.to_string(),
+        out_dir: "backtest_out".to_string(),
+        sigma_window: 60,
+    })
+}
+
+fn params_echo(cfg: &BacktestConfig) -> RunParamsEcho {
+    RunParamsEcho {
+        coin: cfg.coin.clone(),
+        interval: cfg.interval.clone(),
+        start_ms: cfg.start_ms,
+        end_ms: cfg.end_ms,
+        spread: cfg.half_spread.to_string(),
+        depth: cfg.depth.to_string(),
+        commission: cfg.commission.to_string(),
+        starting: cfg.starting_collateral.to_string(),
+        strategies: cfg.strategies.clone(),
+        llm_score: cfg.llm_score,
+    }
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// POST /api/backtest/run — validate, register a `Running` entry, and spawn the harness.
+/// Returns 409 while another run is in progress, 400 on bad params, 202 on accept.
+pub async fn run_backtest_handler(State(s): State<ApiState>, Json(req): Json<RunRequest>) -> Response {
+    let registry = s.backtest_registry.clone();
+
+    // Validate BEFORE claiming the single-run slot so bad params don't need a slot.
+    let cfg = match build_config(&req) {
+        Ok(c) => c,
+        Err(e) => {
+            return (StatusCode::BAD_REQUEST, Json(json!({ "error": e.to_string() }))).into_response();
+        }
+    };
+
+    // One run at a time (rs-backtester process-global CONFIG). The busy-check and the
+    // insert happen under a SINGLE MutexGuard inside `try_begin`, so two concurrent POSTs
+    // cannot both pass the guard and spawn overlapping runs.
+    let id = new_run_id();
+    let admitted = registry.try_begin(BacktestRun {
+        id: id.clone(),
+        params: params_echo(&cfg),
+        status: RunStatus::Running,
+        error: None,
+        started_at: now_rfc3339(),
+        finished_at: None,
+        report: None,
+        equity: None,
+        trades: None,
+    });
+    if !admitted {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": "a backtest run is already in progress" })),
+        )
+            .into_response();
+    }
+
+    // Spawn the harness so the handler returns immediately; the UI polls for status.
+    let reg = registry.clone();
+    let run_id = id.clone();
+    let handle = tokio::spawn(async move {
+        match run_and_collect(&cfg).await {
+            Ok(c) => reg.complete(&run_id, c.report, c.equity, c.trades),
+            Err(e) => reg.fail(&run_id, e.to_string()),
+        }
+    });
+
+    // Observe the JoinHandle: if the run task PANICS (the harness drives the real vipers
+    // over synthetic replay inputs and is not panic-contained), neither `complete` nor
+    // `fail` runs, leaving the entry stuck `Running` forever and wedging the 409 guard
+    // until the LIVE process restarts. On panic we mark it `Failed` so the slot frees.
+    let reg_watch = registry.clone();
+    let watch_id = id.clone();
+    tokio::spawn(async move {
+        if let Err(join_err) = handle.await {
+            if join_err.is_panic() {
+                reg_watch.fail(&watch_id, "backtest task panicked".to_string());
+            }
+        }
+    });
+
+    (StatusCode::ACCEPTED, Json(json!({ "id": id, "status": "running" }))).into_response()
+}
+
+/// GET /api/backtest/runs — list run summaries, newest first.
+pub async fn list_runs_handler(State(s): State<ApiState>) -> Response {
+    Json(s.backtest_registry.summaries_newest_first()).into_response()
+}
+
+/// GET /api/backtest/runs/{id} — full run record (report + equity + trades + scores).
+pub async fn get_run_handler(State(s): State<ApiState>, Path(id): Path<String>) -> Response {
+    match s.backtest_registry.get(&id) {
+        Some(run) => Json(run).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": format!("run '{id}' not found") })),
+        )
+            .into_response(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn echo() -> RunParamsEcho {
+        RunParamsEcho {
+            coin: "BTC".into(),
+            interval: "1m".into(),
+            start_ms: 0,
+            end_ms: 1,
+            spread: "0.02".into(),
+            depth: "500".into(),
+            commission: "0".into(),
+            starting: "500".into(),
+            strategies: None,
+            llm_score: false,
+        }
+    }
+
+    fn running(id: &str) -> BacktestRun {
+        BacktestRun {
+            id: id.into(),
+            params: echo(),
+            status: RunStatus::Running,
+            error: None,
+            started_at: now_rfc3339(),
+            finished_at: None,
+            report: None,
+            equity: None,
+            trades: None,
+        }
+    }
+
+    #[test]
+    fn fresh_registry_is_idle() {
+        let reg = BacktestRegistry::new();
+        assert!(!reg.is_busy());
+        assert!(reg.summaries_newest_first().is_empty());
+        assert!(reg.get("nope").is_none());
+    }
+
+    #[test]
+    fn insert_makes_it_busy() {
+        let reg = BacktestRegistry::new();
+        reg.insert(running("a"));
+        assert!(reg.is_busy());
+    }
+
+    #[test]
+    fn complete_transitions_and_clears_busy() {
+        let reg = BacktestRegistry::new();
+        reg.insert(running("a"));
+        reg.complete("a", json!({"ok": true}), vec![], vec![]);
+        assert!(!reg.is_busy());
+        let run = reg.get("a").unwrap();
+        assert_eq!(run.status, RunStatus::Done);
+        assert!(run.report.is_some());
+        assert!(run.finished_at.is_some());
+        assert!(run.error.is_none());
+    }
+
+    #[test]
+    fn fail_transitions_and_records_error() {
+        let reg = BacktestRegistry::new();
+        reg.insert(running("a"));
+        reg.fail("a", "boom".into());
+        assert!(!reg.is_busy());
+        let run = reg.get("a").unwrap();
+        assert_eq!(run.status, RunStatus::Failed);
+        assert_eq!(run.error.as_deref(), Some("boom"));
+        assert!(run.report.is_none());
+    }
+
+    #[test]
+    fn summaries_are_newest_first() {
+        let reg = BacktestRegistry::new();
+        reg.insert(running("first"));
+        reg.insert(running("second"));
+        let sums = reg.summaries_newest_first();
+        assert_eq!(sums[0].id, "second");
+        assert_eq!(sums[1].id, "first");
+    }
+
+    #[test]
+    fn try_begin_admits_one_then_rejects_until_free() {
+        let reg = BacktestRegistry::new();
+        assert!(reg.try_begin(running("a")), "first run should be admitted");
+        assert!(!reg.try_begin(running("b")), "second run must be rejected while busy");
+        // Finishing the first frees the slot.
+        reg.complete("a", json!({"ok": true}), vec![], vec![]);
+        assert!(reg.try_begin(running("c")), "run admitted after the slot frees");
+        assert!(reg.get("b").is_none(), "rejected run was never inserted");
+    }
+
+    #[test]
+    fn prune_caps_retained_runs_and_keeps_running() {
+        let reg = BacktestRegistry::new();
+        // Seed more than MAX_RUNS finished entries.
+        for i in 0..(MAX_RUNS + 10) {
+            let id = format!("done-{i}");
+            reg.insert(running(&id));
+            reg.complete(&id, json!({}), vec![], vec![]);
+        }
+        assert!(reg.summaries_newest_first().len() <= MAX_RUNS, "registry is capped");
+        // A running entry survives eviction even as new finished ones arrive.
+        reg.insert(running("live"));
+        for i in 0..MAX_RUNS {
+            let id = format!("more-{i}");
+            reg.insert(running(&id));
+            reg.complete(&id, json!({}), vec![], vec![]);
+        }
+        assert!(reg.get("live").is_some(), "the in-flight run is never evicted");
+    }
+
+    #[test]
+    fn build_config_rejects_insane_params() {
+        let base = || RunRequest {
+            coin: "BTC".into(),
+            start: "1000000000".into(),
+            end: "1000003600".into(),
+            interval: None,
+            spread: None,
+            depth: None,
+            commission: None,
+            starting: None,
+            strategies: None,
+            llm_score: None,
+        };
+        let neg_spread = RunRequest { spread: Some("-0.02".into()), ..base() };
+        assert!(build_config(&neg_spread).is_err(), "negative spread rejected");
+        let big_spread = RunRequest { spread: Some("0.9".into()), ..base() };
+        assert!(build_config(&big_spread).is_err(), "spread > 0.5 rejected");
+        let bad_depth = RunRequest { depth: Some("0".into()), ..base() };
+        assert!(build_config(&bad_depth).is_err(), "non-positive depth rejected");
+        let bad_comm = RunRequest { commission: Some("1".into()), ..base() };
+        assert!(build_config(&bad_comm).is_err(), "commission >= 1 rejected");
+        let bad_start = RunRequest { starting: Some("0".into()), ..base() };
+        assert!(build_config(&bad_start).is_err(), "non-positive starting rejected");
+    }
+
+    #[test]
+    fn build_config_applies_cli_defaults() {
+        let req = RunRequest {
+            coin: "btc".into(),
+            start: "1000000000".into(),
+            end: "1000003600".into(),
+            interval: None,
+            spread: None,
+            depth: None,
+            commission: None,
+            starting: None,
+            strategies: None,
+            llm_score: None,
+        };
+        let cfg = build_config(&req).unwrap();
+        assert_eq!(cfg.coin, "BTC");
+        assert_eq!(cfg.crypto_filter, "btc");
+        assert_eq!(cfg.interval, "1m");
+        assert_eq!(cfg.half_spread, Decimal::from_str("0.02").unwrap());
+        assert_eq!(cfg.depth, Decimal::from_str("500").unwrap());
+        assert_eq!(cfg.starting_collateral, Decimal::from_str("500").unwrap());
+        assert!(!cfg.llm_score);
+        assert_eq!(cfg.cache_path, DEFAULT_CACHE_PATH);
+    }
+
+    #[test]
+    fn build_config_rejects_bad_window() {
+        let req = RunRequest {
+            coin: "BTC".into(),
+            start: "1000003600".into(),
+            end: "1000000000".into(),
+            interval: None,
+            spread: None,
+            depth: None,
+            commission: None,
+            starting: None,
+            strategies: None,
+            llm_score: None,
+        };
+        assert!(build_config(&req).is_err());
+    }
+}

--- a/src/api/backtest_api.rs
+++ b/src/api/backtest_api.rs
@@ -29,6 +29,7 @@ use serde_json::json;
 use crate::api::server::ApiState;
 use crate::backtest::entry::{parse_time, run_and_collect, EquityPoint, TradeRecord};
 use crate::backtest::harness::BacktestConfig;
+use crate::backtest::source::SourceKind;
 
 /// Default backtest cache — the CLI default; a SEPARATE sqlite file from the live DB.
 const DEFAULT_CACHE_PATH: &str = "backtest_cache.sqlite";
@@ -64,6 +65,7 @@ pub struct RunParamsEcho {
     pub starting: String,
     pub strategies: Option<Vec<String>>,
     pub llm_score: bool,
+    pub source: String,
 }
 
 /// One registry entry — the full record served by `GET /api/backtest/runs/{id}`.
@@ -239,6 +241,10 @@ pub struct RunRequest {
     pub strategies: Option<Vec<String>>,
     #[serde(default)]
     pub llm_score: Option<bool>,
+    /// Historical-data provider: "hyperliquid" (default) | "binance". Both hit
+    /// public, unauthenticated endpoints — there is no key to configure.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 /// Parse an optional Decimal knob, falling back to `default` when empty/absent.
@@ -300,6 +306,12 @@ fn build_config(req: &RunRequest) -> anyhow::Result<BacktestConfig> {
         })
         .filter(|v| !v.is_empty());
 
+    let source = match req.source.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        None => SourceKind::Hyperliquid,
+        Some(s) => <SourceKind as clap::ValueEnum>::from_str(s, true)
+            .map_err(|_| anyhow::anyhow!("invalid source '{s}' (valid: hyperliquid | binance)"))?,
+    };
+
     Ok(BacktestConfig {
         crypto_filter: coin.to_lowercase(),
         coin,
@@ -315,6 +327,7 @@ fn build_config(req: &RunRequest) -> anyhow::Result<BacktestConfig> {
         cache_path: DEFAULT_CACHE_PATH.to_string(),
         out_dir: "backtest_out".to_string(),
         sigma_window: 60,
+        source,
     })
 }
 
@@ -330,6 +343,7 @@ fn params_echo(cfg: &BacktestConfig) -> RunParamsEcho {
         starting: cfg.starting_collateral.to_string(),
         strategies: cfg.strategies.clone(),
         llm_score: cfg.llm_score,
+        source: cfg.source.as_str().to_string(),
     }
 }
 
@@ -433,6 +447,7 @@ mod tests {
             starting: "500".into(),
             strategies: None,
             llm_score: false,
+            source: "hyperliquid".into(),
         }
     }
 
@@ -544,6 +559,7 @@ mod tests {
             starting: None,
             strategies: None,
             llm_score: None,
+            source: None,
         };
         let neg_spread = RunRequest { spread: Some("-0.02".into()), ..base() };
         assert!(build_config(&neg_spread).is_err(), "negative spread rejected");
@@ -570,6 +586,7 @@ mod tests {
             starting: None,
             strategies: None,
             llm_score: None,
+            source: None,
         };
         let cfg = build_config(&req).unwrap();
         assert_eq!(cfg.coin, "BTC");
@@ -595,7 +612,66 @@ mod tests {
             starting: None,
             strategies: None,
             llm_score: None,
+            source: None,
         };
         assert!(build_config(&req).is_err());
+    }
+
+    #[test]
+    fn build_config_defaults_to_hyperliquid() {
+        let req = RunRequest {
+            coin: "BTC".into(),
+            start: "1000000000".into(),
+            end: "1000003600".into(),
+            interval: None,
+            spread: None,
+            depth: None,
+            commission: None,
+            starting: None,
+            strategies: None,
+            llm_score: None,
+            source: None,
+        };
+        let cfg = build_config(&req).unwrap();
+        assert_eq!(cfg.source, SourceKind::Hyperliquid);
+    }
+
+    #[test]
+    fn build_config_accepts_binance_case_insensitive() {
+        let base = |source: &str| RunRequest {
+            coin: "BTC".into(),
+            start: "1000000000".into(),
+            end: "1000003600".into(),
+            interval: None,
+            spread: None,
+            depth: None,
+            commission: None,
+            starting: None,
+            strategies: None,
+            llm_score: None,
+            source: Some(source.into()),
+        };
+        let cfg = build_config(&base("binance")).unwrap();
+        assert_eq!(cfg.source, SourceKind::Binance);
+        let cfg = build_config(&base("BINANCE")).unwrap();
+        assert_eq!(cfg.source, SourceKind::Binance);
+    }
+
+    #[test]
+    fn build_config_rejects_unknown_source() {
+        let req = RunRequest {
+            coin: "BTC".into(),
+            start: "1000000000".into(),
+            end: "1000003600".into(),
+            interval: None,
+            spread: None,
+            depth: None,
+            commission: None,
+            starting: None,
+            strategies: None,
+            llm_score: None,
+            source: Some("kraken".into()),
+        };
+        assert!(build_config(&req).is_err(), "unknown source 'kraken' rejected");
     }
 }

--- a/src/api/config_schema.rs
+++ b/src/api/config_schema.rs
@@ -76,7 +76,7 @@ pub fn config_schema() -> Vec<ConfigFieldSchema> {
 
     // ── Global ────────────────────────────────────────────────────────────────
     v.push(F::new("Global", None, "ghost_mode", "Ghost Mode", "bool", false,
-        "Simulate all orders — no real CLOB calls (validation framework)."));
+        "Paper-trade NEW orders — depth-aware simulated fills, no real CLOB calls. Reaches running squadrons within ~30s and affects new orders only: open live positions keep trading live until they close (grandfathered); ghost positions stay simulated."));
 
     // ── Arbitrage ───────────────────────────────────────────────────────────────
     {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,5 @@
 pub mod server;
 pub mod config_schema;
+#[cfg(feature = "backtest")]
+pub mod backtest_api;
 

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -251,6 +251,11 @@ pub struct ApiState {
     /// Populated by the telemetry sampler task; served by
     /// GET /api/telemetry/history so the UI survives reloads and can scrub.
     pub telemetry_history: TelemetryHistory,
+    /// In-memory backtest run registry (feature-gated). Backs POST /api/backtest/run
+    /// and the two GET /api/backtest/runs endpoints. Compiled ONLY under
+    /// `--features backtest`, so the default server build is byte-identical.
+    #[cfg(feature = "backtest")]
+    pub backtest_registry: crate::api::backtest_api::BacktestRegistry,
 }
 
 // ─── API-key middleware ──────────────────────────────────────────────────────
@@ -403,6 +408,19 @@ async fn patch_config(State(s): State<ApiState>, body: String) -> Response {
         Ok(new_cfg) => {
             // Broadcast to all strategy tick loops.
             let _ = s.config_tx.send(new_cfg.clone());
+            // Fan the same merge-patch out to every squadron's persisted config so
+            // running intl squadrons pick up the operator's edit on their next
+            // periodic reload (see SQUADRON_CONFIG_RELOAD_SECS in
+            // squadron::patrol_impl) — the global row alone never reaches them.
+            // A merge-patch carries only the keys the operator changed, so applying
+            // it per-squadron preserves each squadron's other (untouched) tuning.
+            if let Some(pool) = db::pool() {
+                for sid in db::squadron_config_list(pool).await {
+                    if let Err(e) = DynamicConfig::apply_squadron_patch(&sid, &body).await {
+                        warn!("Error fanning PATCH /api/config out to squadron {}: {}", sid, e);
+                    }
+                }
+            }
             match serde_json::to_value(new_cfg.as_ref()) {
                 Ok(val) => {
                     debug!("Successfully processed PATCH /api/config");
@@ -550,8 +568,23 @@ struct StatusResponse {
     strategy_markets: HashMap<String, String>,
     /// RFC-3339 timestamp of the current session start (= process startup).
     session_started_at: String,
-    /// Per-asset Binance Raptor connection health.
+    /// Per-asset Raptor connection health.
     raptors: HashMap<String, AssetRaptorHealth>,
+    /// Active market-data source ("binance" | "hyperliquid"). Drives the
+    /// source labels in the Control Tower Raptor/telemetry panels.
+    market_data_source: String,
+    /// Realized paper (ghost) session P&L across all squadrons (Decimal string).
+    /// Segregated from live P&L — see SessionState::paper_pnl.
+    paper_pnl: String,
+    /// Simulated paper collateral balance across all squadrons (Decimal string).
+    paper_balance: String,
+    /// Effective LLM Advisor provider ("ollama" | "anthropic" | "openai" |
+    /// "openai-compatible" | "chatgpt"), resolved the same way the live advisor
+    /// resolves its settings. Never any key material.
+    llm_provider: String,
+    /// Effective LLM Advisor model tag (e.g. "llama3.2", "claude-3-5-sonnet-latest").
+    /// Empty when a cloud provider is selected but no model is configured yet.
+    llm_model: String,
 }
 
 async fn get_status(State(s): State<ApiState>) -> Response {
@@ -559,8 +592,59 @@ async fn get_status(State(s): State<ApiState>) -> Response {
     let markets = s.markets_rx.borrow().clone();
     let raptors = s.raptor_health_rx.borrow().clone();
     let session_started_at = db::current_session_id().to_string();
+    let market_data_source = crate::raptors::source::MarketDataSource::resolve().as_str().to_string();
+
+    // Aggregate the paper ledger across every registered squadron session so the
+    // Control Tower can render paper P&L + balance alongside the live figures.
+    let mut paper_pnl = rust_decimal::Decimal::ZERO;
+    let mut paper_balance = rust_decimal::Decimal::ZERO;
+    for asset in s.cag.asset_names() {
+        if let Some(session) = s.cag.session_for_asset(&asset) {
+            paper_pnl += *session.paper_pnl.lock().await;
+            paper_balance += *session.paper_balance.lock().await;
+        }
+    }
+
+    // Resolve the effective LLM provider/model the same way the live advisor does
+    // (env → compile-time config precedence). The key is never read into the response;
+    // even when settings resolution fails (e.g. a cloud provider without LLM_MODEL) we
+    // still surface the resolved provider name with an empty model.
+    //
+    // Resolve ONCE and cache: the env-derived settings do not change over the process
+    // lifetime, and `resolve_from_env` logs an `error!` when `LLM_PROVIDER` is misconfigured
+    // (falling back to Ollama). Without caching, every 30s status poll would re-emit that
+    // ERROR line, flooding the level operators alert on. The value is process-global and
+    // key-free, so a `OnceLock` is safe.
+    static LLM_STATUS: std::sync::OnceLock<(String, String)> = std::sync::OnceLock::new();
+    let (llm_provider, llm_model) = LLM_STATUS
+        .get_or_init(|| {
+            match crate::helpers::llm_client::LlmSettings::resolve_from_env() {
+                Ok(settings) => (settings.provider.as_str().to_string(), settings.model.clone()),
+                Err(_) => {
+                    let provider = std::env::var("LLM_PROVIDER")
+                        .ok()
+                        .filter(|v| !v.trim().is_empty())
+                        .map(|v| crate::helpers::llm_client::LlmProvider::from_str(&v))
+                        .unwrap_or_else(|| {
+                            crate::helpers::llm_client::LlmProvider::from_str(crate::config::LLM_PROVIDER)
+                        });
+                    (provider.as_str().to_string(), String::new())
+                }
+            }
+        })
+        .clone();
+
     debug!("Successfully retrieved status");
-    Json(StatusResponse { strategy_markets: markets, session_started_at, raptors }).into_response()
+    Json(StatusResponse {
+        strategy_markets: markets,
+        session_started_at,
+        raptors,
+        market_data_source,
+        paper_pnl: paper_pnl.to_string(),
+        paper_balance: paper_balance.to_string(),
+        llm_provider,
+        llm_model,
+    }).into_response()
 }
 
 /// GET /api/telemetry
@@ -906,6 +990,7 @@ async fn manual_exit(
         shares,
         pnl,
         "Manual RTB (Return to Base)".to_string(),
+        false,
     ).await;
 
     // ── Step 7: Close position in DB ───────────────────────────────────────────
@@ -1074,6 +1159,13 @@ async fn get_portfolio_value(State(s): State<ApiState>) -> Response {
         let mut deduped_positions: std::collections::HashMap<String, db::OpenPositionRow> =
             std::collections::HashMap::new();
         for pos in db::get_open_positions(&pool).await {
+            // D7: GHOST (paper) rows are segregated from the LIVE portfolio aggregation
+            // (positions_value / unrealized P&L / position_count). GET /api/positions
+            // still returns them (badged) for the Control Tower; only this live-money
+            // rollup excludes them.
+            if pos.ghost_mode {
+                continue;
+            }
             // Skip UNCONFIRMED phantoms: still `status='pending'` AND not chain-adopted
             // means the order was placed but never confirmed on-chain (never filled or
             // rejected). Valuing it inflates the portfolio with non-existent profit until
@@ -1379,7 +1471,7 @@ pub async fn run_api_server(
     // Server-side ring buffer for Raptor signal telemetry (durable across reloads).
     let telemetry_history: TelemetryHistory = Arc::new(Mutex::new(HashMap::new()));
 
-    let state = ApiState { config_tx, config_rx, markets_rx, raptor_health_rx: raptor_health_rx.clone(), api_key, read_only, #[cfg(feature = "intl_clob")] safe_address, cag, telemetry_history: telemetry_history.clone() };
+    let state = ApiState { config_tx, config_rx, markets_rx, raptor_health_rx: raptor_health_rx.clone(), api_key, read_only, #[cfg(feature = "intl_clob")] safe_address, cag, telemetry_history: telemetry_history.clone(), #[cfg(feature = "backtest")] backtest_registry: crate::api::backtest_api::BacktestRegistry::new() };
 
     // Spawn the telemetry sampler — snapshots live Raptor signals into the ring
     // buffer every TELEMETRY_SAMPLE_SECS so the Control Tower has durable,
@@ -1421,6 +1513,14 @@ pub async fn run_api_server(
     let protected_routes = protected_routes
         .route("/api/positions/sync",        axum::routing::post(sync_positions))
         .route("/api/positions/manual-exit", axum::routing::post(manual_exit));
+
+    // Backtest endpoints (feature-gated). Absent from the default build so the
+    // Control Tower probes GET /api/backtest/runs and hides its Backtest tab on 404.
+    #[cfg(feature = "backtest")]
+    let protected_routes = protected_routes
+        .route("/api/backtest/run",       axum::routing::post(crate::api::backtest_api::run_backtest_handler))
+        .route("/api/backtest/runs",      get(crate::api::backtest_api::list_runs_handler))
+        .route("/api/backtest/runs/{id}", get(crate::api::backtest_api::get_run_handler));
 
     let protected_routes = protected_routes
         // API-key check applied to all matched routes (inner layer — runs after CORS).

--- a/src/backtest/bridge.rs
+++ b/src/backtest/bridge.rs
@@ -1,0 +1,76 @@
+//! W6 — f64⇄Decimal boundary + StrategySignal→rs_backtester::Order mapping.
+//!
+//! rs-backtester is f64-throughout (volume is `u64`) and its `Order{BUY,SHORTSELL,
+//! NULL}` models a LINEAR instrument. The mapping here is therefore a **directional
+//! proxy on the underlying**, NOT the binary YES/NO payoff — the authoritative PnL is
+//! the native Decimal ledger. The proxy exists only to borrow rs-backtester's free
+//! Sharpe/drawdown/win-rate metrics on the candle series:
+//!
+//!   * net long YES exposure  → `Order::BUY`     (long the underlying)
+//!   * net long NO  exposure  → `Order::SHORTSELL`(short the underlying)
+//!   * flat                   → `Order::NULL`
+//!
+//! The harness computes one [`Stance`] per candle from the net position direction
+//! after that tick; `to_orders` lowers the aligned stance vector to rs-backtester's
+//! `choices` (length == candle count, as `broker::calculate` requires).
+
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+
+use rs_backtester::orders::Order;
+
+/// Per-candle net directional stance (a directional proxy, not the binary payoff).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stance {
+    /// Net long YES exposure → long the underlying.
+    Long,
+    /// Net long NO exposure → short the underlying.
+    Short,
+    /// Flat.
+    Flat,
+}
+
+impl Stance {
+    pub fn to_order(self) -> Order {
+        match self {
+            Stance::Long => Order::BUY,
+            Stance::Short => Order::SHORTSELL,
+            Stance::Flat => Order::NULL,
+        }
+    }
+}
+
+/// Lower an aligned stance vector to rs-backtester `choices`.
+pub fn to_orders(stances: &[Stance]) -> Vec<Order> {
+    stances.iter().map(|s| s.to_order()).collect()
+}
+
+/// Decimal → f64 for the rs-backtester f64 boundary (single conversion point).
+pub fn dec_to_f64(d: Decimal) -> f64 {
+    d.to_f64().unwrap_or(0.0)
+}
+
+/// Decimal → u64 for rs-backtester's `volume: Vec<u64>` (truncating, non-negative).
+pub fn dec_to_u64(d: Decimal) -> u64 {
+    d.max(Decimal::ZERO).to_u64().unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn stance_maps_to_orders() {
+        let s = [Stance::Long, Stance::Short, Stance::Flat, Stance::Long];
+        let o = to_orders(&s);
+        assert_eq!(o, vec![Order::BUY, Order::SHORTSELL, Order::NULL, Order::BUY]);
+    }
+
+    #[test]
+    fn decimal_conversions() {
+        assert!((dec_to_f64(dec!(1.25)) - 1.25).abs() < 1e-12);
+        assert_eq!(dec_to_u64(dec!(12.9)), 12);
+        assert_eq!(dec_to_u64(dec!(-5)), 0); // clamped non-negative
+    }
+}

--- a/src/backtest/clock.rs
+++ b/src/backtest/clock.rs
@@ -1,0 +1,90 @@
+//! W3 — Replay clock: maps historical candle timestamps onto a synthetic monotonic
+//! timeline so the W1 clock seam evaluates every viper gate against HISTORICAL time.
+//!
+//! For a candle at historical time `t` (unix millis):
+//!
+//! * `wall(t)` = the historical `DateTime<Utc>` (fed to `ctx.wall_now`,
+//!   `snapshot.timestamp`, and used for `secs_to_expiry`).
+//! * `mono(t)` = `base_instant + (t - t0)` — a synthetic monotonic `Instant`
+//!   (fed to `ctx.mono_now` as `std` and to `PriceKinematics::on_price` as
+//!   `tokio::time::Instant`; both only ever use relative offsets).
+//!
+//! Because `PriceKinematics::on_price` and every cooldown timer read ONLY the passed
+//! `now`, feeding these synthetic instants yields byte-identical signal math to a
+//! live run at any replay speed (the kinematics unit tests prove exactly this).
+
+use chrono::{DateTime, TimeZone, Utc};
+use std::time::Duration;
+
+pub struct ReplayClock {
+    t0_ms: i64,
+    base_std: std::time::Instant,
+    base_tokio: tokio::time::Instant,
+}
+
+impl ReplayClock {
+    /// Anchor the synthetic timeline at historical time `t0_ms` (the first candle).
+    pub fn new(t0_ms: i64) -> Self {
+        Self {
+            t0_ms,
+            base_std: std::time::Instant::now(),
+            base_tokio: tokio::time::Instant::now(),
+        }
+    }
+
+    /// Wall-clock `DateTime<Utc>` for a historical unix-millis timestamp.
+    pub fn wall(&self, ts_ms: i64) -> DateTime<Utc> {
+        Utc.timestamp_millis_opt(ts_ms)
+            .single()
+            .unwrap_or_else(|| Utc.timestamp_opt(0, 0).single().unwrap())
+    }
+
+    /// Monotonic offset from the anchor (saturating at zero for pre-anchor stamps).
+    fn offset(&self, ts_ms: i64) -> Duration {
+        Duration::from_millis((ts_ms - self.t0_ms).max(0) as u64)
+    }
+
+    /// Synthetic `std::time::Instant` for `ctx.mono_now` and viper cooldown timers.
+    pub fn mono_std(&self, ts_ms: i64) -> std::time::Instant {
+        self.base_std + self.offset(ts_ms)
+    }
+
+    /// Synthetic `tokio::time::Instant` for `PriceKinematics::on_price`.
+    pub fn mono_tokio(&self, ts_ms: i64) -> tokio::time::Instant {
+        self.base_tokio + self.offset(ts_ms)
+    }
+
+    /// Seconds from `ts_ms` until `close` (negative once past close).
+    pub fn secs_to_expiry(&self, ts_ms: i64, close: DateTime<Utc>) -> i64 {
+        (close - self.wall(ts_ms)).num_seconds()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wall_roundtrips_millis() {
+        let c = ReplayClock::new(1_700_000_000_000);
+        assert_eq!(c.wall(1_700_000_000_000).timestamp_millis(), 1_700_000_000_000);
+    }
+
+    #[test]
+    fn mono_offset_is_relative_and_monotonic() {
+        let c = ReplayClock::new(1_000_000);
+        let a = c.mono_std(1_000_000);
+        let b = c.mono_std(1_060_000); // +60s
+        assert_eq!(b.duration_since(a), Duration::from_secs(60));
+        // Pre-anchor saturates to the base (no panic, no underflow).
+        assert_eq!(c.mono_std(0).duration_since(a), Duration::ZERO);
+    }
+
+    #[test]
+    fn secs_to_expiry_counts_down() {
+        let c = ReplayClock::new(0);
+        let close = c.wall(3_600_000); // 1h after anchor
+        assert_eq!(c.secs_to_expiry(0, close), 3600);
+        assert_eq!(c.secs_to_expiry(3_000_000, close), 600);
+    }
+}

--- a/src/backtest/entry.rs
+++ b/src/backtest/entry.rs
@@ -1,0 +1,126 @@
+//! Shared backtest entry point — used by BOTH the CLI (`src/bin/backtest.rs`) and the
+//! feature-gated Control Tower backtest API (`src/api/backtest_api.rs`), so the two
+//! never drift. Owns the CLI-style timestamp parser and a file-free run pipeline that
+//! collects the report/equity/trades payload the API stores in its run registry.
+
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use super::bridge::dec_to_f64;
+use super::harness::{run_backtest, BacktestConfig, BacktestOutcome};
+use super::report::{build_report_json, run_rs_backtester};
+
+/// One equity-curve sample (string-encoded Decimal, mirroring the rest of the API).
+#[derive(Debug, Clone, Serialize)]
+pub struct EquityPoint {
+    pub ts: String,
+    pub equity: String,
+}
+
+/// One closed trade row (string-encoded Decimals; mirrors the trades.csv columns).
+#[derive(Debug, Clone, Serialize)]
+pub struct TradeRecord {
+    pub strategy: String,
+    pub side: String,
+    pub kind: String,
+    pub entry_ts: String,
+    pub exit_ts: String,
+    pub entry_price: String,
+    pub exit_price: String,
+    pub shares: String,
+    pub pnl: String,
+    pub reason: String,
+}
+
+/// The full collected result of one backtest run (report JSON + equity + trades).
+pub struct CollectedRun {
+    pub report: serde_json::Value,
+    pub equity: Vec<EquityPoint>,
+    pub trades: Vec<TradeRecord>,
+}
+
+/// Run the harness + rs-backtester directional proxy for `cfg` and collect the
+/// report/equity/trades payload WITHOUT writing any files (the CLI writes its own
+/// via `report::write_native`; the API keeps everything in its in-memory registry).
+pub async fn run_and_collect(cfg: &BacktestConfig) -> Result<CollectedRun> {
+    let outcome = run_backtest(cfg).await?;
+    let rs = run_rs_backtester(
+        &cfg.coin,
+        &outcome.candles,
+        &outcome.stances,
+        cfg.commission,
+        dec_to_f64(cfg.starting_collateral),
+    );
+    let report = build_report_json(cfg, &outcome, &rs);
+    let equity = collect_equity(&outcome);
+    let trades = collect_trades(&outcome);
+    Ok(CollectedRun { report, equity, trades })
+}
+
+fn collect_equity(outcome: &BacktestOutcome) -> Vec<EquityPoint> {
+    outcome
+        .ledger
+        .equity_curve()
+        .iter()
+        .map(|(ts, eq)| EquityPoint {
+            ts: ts.to_rfc3339(),
+            equity: eq.to_string(),
+        })
+        .collect()
+}
+
+fn collect_trades(outcome: &BacktestOutcome) -> Vec<TradeRecord> {
+    outcome
+        .ledger
+        .closed_trades()
+        .iter()
+        .map(|t| TradeRecord {
+            strategy: t.strategy.clone(),
+            side: t.side.clone(),
+            kind: format!("{:?}", t.kind),
+            entry_ts: t.entry_ts.to_rfc3339(),
+            exit_ts: t.exit_ts.to_rfc3339(),
+            entry_price: t.entry_price.to_string(),
+            exit_price: t.exit_price.to_string(),
+            shares: t.shares.to_string(),
+            pnl: t.pnl.to_string(),
+            reason: t.reason.clone(),
+        })
+        .collect()
+}
+
+/// Parse a timestamp: rfc3339, unix seconds (≤11 digits) or millis (≥12), or a
+/// relative `now` / `now-<N>[smhd]` expression. Returns unix milliseconds.
+///
+/// Shared by the CLI arg parser and the API run form so both accept identical inputs.
+pub fn parse_time(s: &str) -> Result<i64> {
+    let s = s.trim();
+    if let Some(rest) = s.strip_prefix("now") {
+        let now = Utc::now().timestamp_millis();
+        if rest.is_empty() {
+            return Ok(now);
+        }
+        // Expect "-<N><unit>" or "+<N><unit>".
+        let sign = if rest.starts_with('-') { -1 } else { 1 };
+        let body = rest.trim_start_matches(['-', '+']);
+        let (num, unit) = body.split_at(body.len().saturating_sub(1));
+        let n: i64 = num.parse().with_context(|| format!("bad relative time '{s}'"))?;
+        let mult_ms = match unit {
+            "s" => 1_000,
+            "m" => 60_000,
+            "h" => 3_600_000,
+            "d" => 86_400_000,
+            _ => bail!("unknown time unit in '{s}' (use s/m/h/d)"),
+        };
+        return Ok(now + sign * n * mult_ms);
+    }
+    if s.chars().all(|c| c.is_ascii_digit()) {
+        let v: i64 = s.parse().context("parsing numeric timestamp")?;
+        // ≤ 11 digits → seconds; otherwise milliseconds.
+        return Ok(if s.len() <= 11 { v * 1000 } else { v });
+    }
+    let dt = DateTime::parse_from_rfc3339(s)
+        .with_context(|| format!("parsing rfc3339 timestamp '{s}'"))?;
+    Ok(dt.with_timezone(&Utc).timestamp_millis())
+}

--- a/src/backtest/fetch.rs
+++ b/src/backtest/fetch.rs
@@ -1,31 +1,39 @@
 //! W2 — Historical data fetch + SQLite cache.
 //!
-//! Async fetchers against the public Hyperliquid Info API
-//! (`https://api.hyperliquid.xyz/info`) using plain `reqwest` 0.12 POSTs — the same
-//! wire shape `src/helpers/time.rs::fetch_hyperliquid_close` already uses, so no SDK
-//! and no `hyperliquid` cargo feature are required.
+//! The cache is provider-agnostic: it drives coverage checks and SQLite storage
+//! against any `&dyn HistoricalSource` (`source::HistoricalSource`), which owns the
+//! ENTIRE wire protocol (endpoint, request shape, its own pagination loop, auth
+//! header) for one historical-market-data provider — Hyperliquid's public info API
+//! by default, or Binance FAPI via `--source binance`. See `source/mod.rs` for the
+//! trait and `source/{hyperliquid,binance}.rs` for the two implementations.
 //!
-//!   * `candleSnapshot` — 1m OHLCV. The endpoint caps each response at ~5000 candles,
-//!     so we paginate by advancing `startTime` past the last returned candle. Every
-//!     OHLCV field is a JSON STRING → parsed with `Decimal::from_str`. NOTE: the API
-//!     also RETAINS only the most recent ~5000 candles and anchors responses at the
-//!     TAIL, so a requested window older than ~5000×interval is head-truncated at the
-//!     source (unfetchable) — the harness detects this and warns; the still-forming
-//!     current candle is never cached (its OHLCV is provisional until the bar closes).
-//!   * `fundingHistory` — hourly funding series, paginated the same way.
+//! Rows are keyed by `(source, coin, interval, ts)` / `(source, coin, ts)` so
+//! different providers never collide in the same cache file. `BacktestCache` centralizes
+//! two provider-agnostic caching-correctness rules in its insert path (`upsert_candles`/
+//! `upsert_funding`), so no provider implementation can get them wrong:
+//!   * a candle is never persisted while it is still forming (`ts + step > now_ms`) —
+//!     its OHLCV is provisional until the bar closes, and `INSERT OR IGNORE` would
+//!     freeze those partial values PERMANENTLY, making reruns non-reproducible;
+//!   * rows at or past `end_ms` are dropped (a provider may over-fetch its last page).
+//!
+//! Funding rates are cached RAW, in the provider's own native cadence (Hyperliquid:
+//! hourly; Binance FAPI: per-8h) — normalization onto the canonical per-8h scale
+//! happens in `synth::normalize_funding`, not here; we cache exactly what the API
+//! returned.
 //!
 //! Results are cached in a SEPARATE SQLite file (default `backtest_cache.sqlite`,
 //! `--cache <path>`), with its OWN pool/schema — the live trading DB is never touched.
 //! Fetches fill gaps only: a range already densely cached is served from disk with no
-//! network round-trip. Pages are rate-limited (~200ms) to stay polite.
+//! network round-trip.
 
 use std::str::FromStr;
-use std::time::Duration;
 
 use anyhow::{Context, Result};
 use rust_decimal::Decimal;
 use sqlx::{sqlite::SqlitePoolOptions, Row, SqlitePool};
 use tracing::{debug, info};
+
+use super::source::HistoricalSource;
 
 /// One OHLCV bar. Timestamps are the candle OPEN time in unix milliseconds (UTC).
 #[derive(Debug, Clone)]
@@ -38,30 +46,45 @@ pub struct Candle {
     pub volume: Decimal,
 }
 
-/// One funding observation: the HL HOURLY funding rate at `ts_ms` (UTC millis).
-/// Normalization to Binance's per-8h scale (×8) happens in `synth`, not here — we
-/// cache the raw rate exactly as the API returned it.
+/// One funding observation: the funding rate at `ts_ms` (UTC millis), in the
+/// PROVIDER'S NATIVE cadence — see the `source` column it is cached under
+/// (`HistoricalSource::funding_period_hours`). Normalization to the canonical
+/// per-8h scale happens in `synth`, not here — we cache the raw rate exactly as
+/// the API returned it.
 #[derive(Debug, Clone)]
 pub struct FundingPoint {
     pub ts_ms: i64,
     pub rate: Decimal,
 }
 
-const INFO_URL: &str = "https://api.hyperliquid.xyz/info";
-const PAGE_DELAY: Duration = Duration::from_millis(200);
-/// Interval step in ms for the 1m default (used for coverage/gap checks).
-fn interval_ms(interval: &str) -> i64 {
-    match interval {
+/// Interval step in ms (used for coverage/gap checks and still-forming-bar math).
+/// Covers both Hyperliquid's and Binance FAPI's interval vocabularies.
+///
+/// Unknown intervals are a HARD ERROR, never a default: some strings we don't
+/// enumerate are wire-valid (Binance FAPI happily serves `1M` monthly candles),
+/// and silently assuming a 1-minute step there would both paginate wrongly and —
+/// worse — defeat `upsert_candles`'s still-forming-bar guard (`ts + step > now`),
+/// permanently freezing a provisional wide bar's OHLCV into the cache.
+pub(crate) fn interval_ms(interval: &str) -> Result<i64> {
+    Ok(match interval {
         "1m" => 60_000,
         "3m" => 180_000,
         "5m" => 300_000,
         "15m" => 900_000,
         "30m" => 1_800_000,
         "1h" => 3_600_000,
+        "2h" => 7_200_000,
         "4h" => 14_400_000,
+        "6h" => 21_600_000,
+        "8h" => 28_800_000,
+        "12h" => 43_200_000,
         "1d" => 86_400_000,
-        _ => 60_000,
-    }
+        "3d" => 259_200_000,
+        "1w" => 604_800_000,
+        other => anyhow::bail!(
+            "unsupported --interval '{other}' (supported: 1m 3m 5m 15m 30m 1h 2h 4h 6h 8h 12h 1d 3d 1w)"
+        ),
+    })
 }
 
 /// Backtest-only SQLite cache. Distinct pool + schema from `helpers::db` — never
@@ -71,7 +94,8 @@ pub struct BacktestCache {
 }
 
 impl BacktestCache {
-    /// Open (creating if absent) the cache DB at `path` and ensure the schema.
+    /// Open (creating if absent) the cache DB at `path`, migrate a legacy
+    /// (pre-`source`-column) schema if present, and ensure the current schema.
     pub async fn open(path: &str) -> Result<Self> {
         let url = format!("sqlite://{}?mode=rwc", path);
         let pool = SqlitePoolOptions::new()
@@ -80,8 +104,12 @@ impl BacktestCache {
             .await
             .with_context(|| format!("opening backtest cache at {path}"))?;
 
+        migrate_legacy_schema(&pool, "candles", &["coin", "interval", "ts", "o", "h", "l", "c", "v"]).await?;
+        migrate_legacy_schema(&pool, "funding", &["coin", "ts", "rate"]).await?;
+
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS candles (
+                source   TEXT NOT NULL,
                 coin     TEXT NOT NULL,
                 interval TEXT NOT NULL,
                 ts       INTEGER NOT NULL,
@@ -90,7 +118,7 @@ impl BacktestCache {
                 l        TEXT NOT NULL,
                 c        TEXT NOT NULL,
                 v        TEXT NOT NULL,
-                PRIMARY KEY (coin, interval, ts)
+                PRIMARY KEY (source, coin, interval, ts)
             )",
         )
         .execute(&pool)
@@ -98,10 +126,11 @@ impl BacktestCache {
 
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS funding (
-                coin TEXT NOT NULL,
-                ts   INTEGER NOT NULL,
-                rate TEXT NOT NULL,
-                PRIMARY KEY (coin, ts)
+                source TEXT NOT NULL,
+                coin   TEXT NOT NULL,
+                ts     INTEGER NOT NULL,
+                rate   TEXT NOT NULL,
+                PRIMARY KEY (source, coin, ts)
             )",
         )
         .execute(&pool)
@@ -118,23 +147,26 @@ impl BacktestCache {
 
     // ── Candles ───────────────────────────────────────────────────────────────
 
-    /// Load candles for `[start_ms, end_ms)`, fetching from Hyperliquid only for the
-    /// portion of the range not already densely cached. Returns them sorted ascending.
+    /// Load candles for `[start_ms, end_ms)`, fetching from `source` only for the
+    /// portion of the range not already densely cached under this source's key.
+    /// Returns them sorted ascending.
     pub async fn load_candles(
         &self,
-        http: &reqwest::Client,
+        source: &dyn HistoricalSource,
         coin: &str,
         interval: &str,
         start_ms: i64,
         end_ms: i64,
     ) -> Result<Vec<Candle>> {
-        let step = interval_ms(interval);
+        let sid = source.id();
+        let step = interval_ms(interval)?;
         let expected = ((end_ms - start_ms) / step).max(1);
 
         let row = sqlx::query(
             "SELECT COUNT(*) AS n, MIN(ts) AS lo, MAX(ts) AS hi
-             FROM candles WHERE coin=? AND interval=? AND ts>=? AND ts<?",
+             FROM candles WHERE source=? AND coin=? AND interval=? AND ts>=? AND ts<?",
         )
+        .bind(sid)
         .bind(coin)
         .bind(interval)
         .bind(start_ms)
@@ -151,16 +183,18 @@ impl BacktestCache {
             && n as f64 >= expected as f64 * 0.90;
 
         if covered {
-            debug!("🗃️  candles [{coin} {interval}] served from cache ({n} rows)");
+            debug!("🗃️  candles [{sid}:{coin} {interval}] served from cache ({n} rows)");
         } else {
-            info!("🌐 fetching candles [{coin} {interval}] {start_ms}..{end_ms} (cache had {n})");
-            self.fetch_candles_range(http, coin, interval, start_ms, end_ms).await?;
+            info!("🌐 fetching candles [{sid}:{coin} {interval}] {start_ms}..{end_ms} (cache had {n})");
+            let fetched = source.fetch_candles(coin, interval, start_ms, end_ms).await?;
+            self.upsert_candles(sid, coin, interval, end_ms, step, fetched).await?;
         }
 
         let rows = sqlx::query(
             "SELECT ts, o, h, l, c, v FROM candles
-             WHERE coin=? AND interval=? AND ts>=? AND ts<? ORDER BY ts ASC",
+             WHERE source=? AND coin=? AND interval=? AND ts>=? AND ts<? ORDER BY ts ASC",
         )
+        .bind(sid)
         .bind(coin)
         .bind(interval)
         .bind(start_ms)
@@ -172,27 +206,30 @@ impl BacktestCache {
         for r in rows {
             out.push(Candle {
                 ts_ms: r.get::<i64, _>("ts"),
-                open: dec(r.get::<String, _>("o"))?,
-                high: dec(r.get::<String, _>("h"))?,
-                low: dec(r.get::<String, _>("l"))?,
-                close: dec(r.get::<String, _>("c"))?,
-                volume: dec(r.get::<String, _>("v"))?,
+                open: dec(&r.get::<String, _>("o"))?,
+                high: dec(&r.get::<String, _>("h"))?,
+                low: dec(&r.get::<String, _>("l"))?,
+                close: dec(&r.get::<String, _>("c"))?,
+                volume: dec(&r.get::<String, _>("v"))?,
             });
         }
         Ok(out)
     }
 
-    /// Paginated `candleSnapshot` fetch, upserting each page (INSERT OR IGNORE).
-    async fn fetch_candles_range(
+    /// Upsert a batch of already-fetched candles (INSERT OR IGNORE), centralizing
+    /// the two provider-agnostic caching-correctness guards: never persist a
+    /// still-forming bar, and never persist past `end_ms`. This is the ONE place
+    /// either rule is enforced, so no provider can drift from the other.
+    async fn upsert_candles(
         &self,
-        http: &reqwest::Client,
+        sid: &str,
         coin: &str,
         interval: &str,
-        start_ms: i64,
         end_ms: i64,
+        step: i64,
+        candles: Vec<Candle>,
     ) -> Result<()> {
-        let step = interval_ms(interval);
-        // Wall-clock now, to reject the currently-forming candle (see the `t + step`
+        // Wall-clock now, to reject the currently-forming candle (see the `ts_ms + step`
         // check below): its provisional OHLCV keeps moving until the interval closes,
         // and `INSERT OR IGNORE` would cache those partial values PERMANENTLY, making
         // reruns non-reproducible against the final bar.
@@ -200,99 +237,62 @@ impl BacktestCache {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis() as i64)
             .unwrap_or(i64::MAX);
-        let mut cursor = start_ms;
+        let mut tx = self.pool.begin().await?;
         let mut total = 0usize;
-        while cursor < end_ms {
-            let body = serde_json::json!({
-                "type": "candleSnapshot",
-                "req": { "coin": coin, "interval": interval, "startTime": cursor, "endTime": end_ms }
-            });
-            let json: serde_json::Value = http
-                .post(INFO_URL)
-                .json(&body)
-                .send()
-                .await
-                .context("candleSnapshot POST failed")?
-                .json()
-                .await
-                .context("candleSnapshot decode failed")?;
-            let arr = json.as_array().cloned().unwrap_or_default();
-            if arr.is_empty() {
-                break;
+        for c in candles {
+            if c.ts_ms >= end_ms {
+                continue;
             }
-            let mut max_t = cursor;
-            let mut tx = self.pool.begin().await?;
-            for c in &arr {
-                let (Some(t), Some(o), Some(h), Some(l), Some(cl), Some(v)) = (
-                    c.get("t").and_then(|x| x.as_i64()),
-                    c.get("o").and_then(|x| x.as_str()),
-                    c.get("h").and_then(|x| x.as_str()),
-                    c.get("l").and_then(|x| x.as_str()),
-                    c.get("c").and_then(|x| x.as_str()),
-                    c.get("v").and_then(|x| x.as_str()),
-                ) else {
-                    continue;
-                };
-                if t >= end_ms {
-                    continue;
-                }
-                // Skip the still-forming candle for the current interval: it closes at
-                // `t + step`, so if that is in the future its OHLCV is provisional and
-                // must never be cached (would be frozen by INSERT OR IGNORE forever).
-                if t + step > now_ms {
-                    continue;
-                }
-                max_t = max_t.max(t);
-                sqlx::query(
-                    "INSERT OR IGNORE INTO candles (coin,interval,ts,o,h,l,c,v)
-                     VALUES (?,?,?,?,?,?,?,?)",
-                )
-                .bind(coin)
-                .bind(interval)
-                .bind(t)
-                .bind(o)
-                .bind(h)
-                .bind(l)
-                .bind(cl)
-                .bind(v)
-                .execute(&mut *tx)
-                .await?;
-                total += 1;
+            // Still-forming bar — provider-agnostic guard (see module doc).
+            if c.ts_ms + step > now_ms {
+                continue;
             }
-            tx.commit().await?;
-
-            // Advance past the last candle we saw; guarantee forward progress.
-            let next = max_t + step;
-            if next <= cursor {
-                break;
-            }
-            cursor = next;
-            // Stop once a short page (< cap) tells us we reached the tail.
-            if arr.len() < 4000 {
-                break;
-            }
-            tokio::time::sleep(PAGE_DELAY).await;
+            sqlx::query(
+                "INSERT OR IGNORE INTO candles (source,coin,interval,ts,o,h,l,c,v)
+                 VALUES (?,?,?,?,?,?,?,?,?)",
+            )
+            .bind(sid)
+            .bind(coin)
+            .bind(interval)
+            .bind(c.ts_ms)
+            .bind(c.open.to_string())
+            .bind(c.high.to_string())
+            .bind(c.low.to_string())
+            .bind(c.close.to_string())
+            .bind(c.volume.to_string())
+            .execute(&mut *tx)
+            .await?;
+            total += 1;
         }
-        info!("✅ candles fetched/cached: {total} rows [{coin} {interval}]");
+        tx.commit().await?;
+        info!("✅ candles fetched/cached: {total} rows [{sid}:{coin} {interval}]");
         Ok(())
     }
 
     // ── Funding ───────────────────────────────────────────────────────────────
 
-    /// Load the funding series for `[start_ms, end_ms)`, fetching from Hyperliquid
-    /// only when the cached range does not already cover it. Sorted ascending.
+    /// Load the funding series for `[start_ms, end_ms)`, fetching from `source` only
+    /// when the cached range does not already cover it (in this source's native
+    /// cadence). Sorted ascending, rates in the provider's native cadence.
     pub async fn load_funding(
         &self,
-        http: &reqwest::Client,
+        source: &dyn HistoricalSource,
         coin: &str,
         start_ms: i64,
         end_ms: i64,
     ) -> Result<Vec<FundingPoint>> {
-        let hour = 3_600_000i64;
+        let sid = source.id();
+        // Coverage slack in the PROVIDER'S cadence: an hourly series (HL) can
+        // legitimately end up to ~1h before `end_ms`, but an 8h-cadence series
+        // (Binance) can legitimately end up to ~8h before it — hardcoding the HL
+        // slack here would make Binance's funding look permanently under-covered
+        // and refetch every run.
+        let cadence_ms = (source.funding_period_hours() as i64).max(1) * 3_600_000;
         let row = sqlx::query(
             "SELECT COUNT(*) AS n, MIN(ts) AS lo, MAX(ts) AS hi
-             FROM funding WHERE coin=? AND ts>=? AND ts<?",
+             FROM funding WHERE source=? AND coin=? AND ts>=? AND ts<?",
         )
+        .bind(sid)
         .bind(coin)
         .bind(start_ms)
         .bind(end_ms)
@@ -302,19 +302,21 @@ impl BacktestCache {
         let lo: Option<i64> = row.try_get("lo").ok();
         let hi: Option<i64> = row.try_get("hi").ok();
         let covered = n > 0
-            && lo.map(|l| l <= start_ms + 2 * hour).unwrap_or(false)
-            && hi.map(|h| h >= end_ms - 2 * hour).unwrap_or(false);
+            && lo.map(|l| l <= start_ms + 2 * cadence_ms).unwrap_or(false)
+            && hi.map(|h| h >= end_ms - 2 * cadence_ms).unwrap_or(false);
 
         if covered {
-            debug!("🗃️  funding [{coin}] served from cache ({n} rows)");
+            debug!("🗃️  funding [{sid}:{coin}] served from cache ({n} rows)");
         } else {
-            info!("🌐 fetching funding [{coin}] {start_ms}..{end_ms} (cache had {n})");
-            self.fetch_funding_range(http, coin, start_ms, end_ms).await?;
+            info!("🌐 fetching funding [{sid}:{coin}] {start_ms}..{end_ms} (cache had {n})");
+            let fetched = source.fetch_funding(coin, start_ms, end_ms).await?;
+            self.upsert_funding(sid, coin, end_ms, fetched).await?;
         }
 
         let rows = sqlx::query(
-            "SELECT ts, rate FROM funding WHERE coin=? AND ts>=? AND ts<? ORDER BY ts ASC",
+            "SELECT ts, rate FROM funding WHERE source=? AND coin=? AND ts>=? AND ts<? ORDER BY ts ASC",
         )
+        .bind(sid)
         .bind(coin)
         .bind(start_ms)
         .bind(end_ms)
@@ -324,93 +326,389 @@ impl BacktestCache {
         for r in rows {
             out.push(FundingPoint {
                 ts_ms: r.get::<i64, _>("ts"),
-                rate: dec(r.get::<String, _>("rate"))?,
+                rate: dec(&r.get::<String, _>("rate"))?,
             });
         }
         Ok(out)
     }
 
-    async fn fetch_funding_range(
+    /// Upsert a batch of already-fetched funding points (INSERT OR IGNORE). No
+    /// still-forming-bar guard applies to funding (a discrete event, not an
+    /// interval bar) — only the `ts < end_ms` bound.
+    async fn upsert_funding(
         &self,
-        http: &reqwest::Client,
+        sid: &str,
         coin: &str,
-        start_ms: i64,
         end_ms: i64,
+        points: Vec<FundingPoint>,
     ) -> Result<()> {
-        let mut cursor = start_ms;
+        let mut tx = self.pool.begin().await?;
         let mut total = 0usize;
-        while cursor < end_ms {
-            let body = serde_json::json!({
-                "type": "fundingHistory", "coin": coin, "startTime": cursor, "endTime": end_ms
-            });
-            let json: serde_json::Value = http
-                .post(INFO_URL)
-                .json(&body)
-                .send()
-                .await
-                .context("fundingHistory POST failed")?
-                .json()
-                .await
-                .context("fundingHistory decode failed")?;
-            let arr = json.as_array().cloned().unwrap_or_default();
-            if arr.is_empty() {
-                break;
+        for f in points {
+            if f.ts_ms >= end_ms {
+                continue;
             }
-            let mut max_t = cursor;
-            let mut tx = self.pool.begin().await?;
-            for f in &arr {
-                let (Some(t), Some(rate)) = (
-                    f.get("time").and_then(|x| x.as_i64()),
-                    f.get("fundingRate").and_then(|x| x.as_str()),
-                ) else {
-                    continue;
-                };
-                if t >= end_ms {
-                    continue;
-                }
-                max_t = max_t.max(t);
-                sqlx::query("INSERT OR IGNORE INTO funding (coin,ts,rate) VALUES (?,?,?)")
-                    .bind(coin)
-                    .bind(t)
-                    .bind(rate)
-                    .execute(&mut *tx)
-                    .await?;
-                total += 1;
-            }
-            tx.commit().await?;
-            let next = max_t + 1;
-            if next <= cursor {
-                break;
-            }
-            cursor = next;
-            if arr.len() < 400 {
-                break;
-            }
-            tokio::time::sleep(PAGE_DELAY).await;
+            sqlx::query("INSERT OR IGNORE INTO funding (source,coin,ts,rate) VALUES (?,?,?,?)")
+                .bind(sid)
+                .bind(coin)
+                .bind(f.ts_ms)
+                .bind(f.rate.to_string())
+                .execute(&mut *tx)
+                .await?;
+            total += 1;
         }
-        info!("✅ funding fetched/cached: {total} rows [{coin}]");
+        tx.commit().await?;
+        info!("✅ funding fetched/cached: {total} rows [{sid}:{coin}]");
         Ok(())
     }
 }
 
-fn dec(s: String) -> Result<Decimal> {
+/// Data-preserving migration for one table from the pre-refactor (no `source`
+/// column) schema to the source-keyed schema. A no-op if `table` doesn't exist yet
+/// (fresh cache file) or already has a `source` column (already migrated) — so
+/// calling this unconditionally on every `open()` is idempotent. MUST run BEFORE
+/// the `CREATE TABLE IF NOT EXISTS` statements, since the migration itself creates
+/// the new table.
+///
+/// Every pre-refactor row was fetched from Hyperliquid (it was the only source),
+/// so migrated rows are tagged `source='hyperliquid'` — correct by construction.
+/// This is a data-preserving `RENAME`+`INSERT`, never a `DROP`+recreate: Hyperliquid's
+/// API retains only the most recent ~5000 candles, so dropping a user's existing
+/// cache would PERMANENTLY destroy any history older than that, not just cause a
+/// one-time refetch.
+async fn migrate_legacy_schema(pool: &SqlitePool, table: &str, legacy_cols: &[&str]) -> Result<()> {
+    let exists: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?",
+    )
+    .bind(table)
+    .fetch_one(pool)
+    .await?;
+    if exists == 0 {
+        return Ok(()); // fresh cache file — nothing to migrate
+    }
+
+    let has_source: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info(?) WHERE name='source'",
+    )
+    .bind(table)
+    .fetch_one(pool)
+    .await?;
+    if has_source >= 1 {
+        return Ok(()); // already migrated
+    }
+
+    let legacy_table = format!("{table}_legacy");
+    let cols = legacy_cols.join(", ");
+    let mut tx = pool.begin().await?;
+    sqlx::query(&format!("ALTER TABLE {table} RENAME TO {legacy_table}"))
+        .execute(&mut *tx)
+        .await?;
+    let create_sql = match table {
+        "candles" => {
+            "CREATE TABLE candles (
+                source   TEXT NOT NULL,
+                coin     TEXT NOT NULL,
+                interval TEXT NOT NULL,
+                ts       INTEGER NOT NULL,
+                o        TEXT NOT NULL,
+                h        TEXT NOT NULL,
+                l        TEXT NOT NULL,
+                c        TEXT NOT NULL,
+                v        TEXT NOT NULL,
+                PRIMARY KEY (source, coin, interval, ts)
+            )"
+        }
+        "funding" => {
+            "CREATE TABLE funding (
+                source TEXT NOT NULL,
+                coin   TEXT NOT NULL,
+                ts     INTEGER NOT NULL,
+                rate   TEXT NOT NULL,
+                PRIMARY KEY (source, coin, ts)
+            )"
+        }
+        _ => unreachable!("migrate_legacy_schema only called for candles/funding"),
+    };
+    sqlx::query(create_sql).execute(&mut *tx).await?;
+    sqlx::query(&format!(
+        "INSERT INTO {table} (source, {cols}) SELECT 'hyperliquid', {cols} FROM {legacy_table}"
+    ))
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(&format!("DROP TABLE {legacy_table}"))
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    info!("📦 migrated legacy backtest cache → source-keyed schema ({table})");
+    Ok(())
+}
+
+pub(crate) fn dec(s: &str) -> Result<Decimal> {
     Decimal::from_str(s.trim()).with_context(|| format!("parsing decimal from '{s}'"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
 
     #[test]
     fn interval_ms_known_values() {
-        assert_eq!(interval_ms("1m"), 60_000);
-        assert_eq!(interval_ms("1h"), 3_600_000);
-        assert_eq!(interval_ms("weird"), 60_000); // graceful default
+        assert_eq!(interval_ms("1m").unwrap(), 60_000);
+        assert_eq!(interval_ms("1h").unwrap(), 3_600_000);
+        assert_eq!(interval_ms("8h").unwrap(), 28_800_000);
+    }
+
+    /// Unknown intervals must FAIL, never default: `1M` is wire-valid on Binance
+    /// FAPI, and a silent 60s step would defeat the still-forming-bar guard and
+    /// permanently cache a provisional monthly bar.
+    #[test]
+    fn interval_ms_rejects_unknown_intervals() {
+        assert!(interval_ms("weird").is_err());
+        assert!(interval_ms("1M").is_err());
+        assert!(interval_ms("").is_err());
     }
 
     #[test]
     fn dec_parses_string_ohlcv() {
-        assert_eq!(dec("42055.5".to_string()).unwrap(), Decimal::from_str("42055.5").unwrap());
-        assert!(dec("not-a-number".to_string()).is_err());
+        assert_eq!(dec("42055.5").unwrap(), Decimal::from_str("42055.5").unwrap());
+        assert!(dec("not-a-number").is_err());
+    }
+
+    // ── Async SQLite tests ───────────────────────────────────────────────────
+    //
+    // Each test opens its own uniquely-named SQLite file under the OS temp dir
+    // (no shared fixture, no `tempfile` crate dependency needed) and removes it
+    // on the way out. A dummy `HistoricalSource` stub panics if `fetch_candles`/
+    // `fetch_funding` are ever actually invoked, so a test that expects to be
+    // served entirely from cache also proves no network call was attempted.
+
+    /// A `HistoricalSource` stub whose fetch methods panic — used wherever a test
+    /// pre-seeds the cache such that `load_*` must be served without fetching.
+    struct PanicSource {
+        sid: &'static str,
+        funding_hours: u32,
+    }
+
+    #[async_trait]
+    impl HistoricalSource for PanicSource {
+        fn id(&self) -> &'static str {
+            self.sid
+        }
+        fn resolve_symbol(&self, coin: &str) -> String {
+            coin.to_string()
+        }
+        fn funding_period_hours(&self) -> u32 {
+            self.funding_hours
+        }
+        async fn fetch_candles(
+            &self,
+            _coin: &str,
+            _interval: &str,
+            _start_ms: i64,
+            _end_ms: i64,
+        ) -> Result<Vec<Candle>> {
+            panic!("fetch_candles must not be called when the cache is already covered");
+        }
+        async fn fetch_funding(
+            &self,
+            _coin: &str,
+            _start_ms: i64,
+            _end_ms: i64,
+        ) -> Result<Vec<FundingPoint>> {
+            panic!("fetch_funding must not be called when the cache is already covered");
+        }
+    }
+
+    /// A unique, unshared SQLite file path under the OS temp dir for one test.
+    fn temp_db_path(tag: &str) -> String {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!("dradis_backtest_fetch_test_{tag}_{nanos}.sqlite"))
+            .to_string_lossy()
+            .to_string()
+    }
+
+    /// Best-effort cleanup of a temp cache file and its SQLite sidecar files.
+    fn cleanup_db(path: &str) {
+        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(format!("{path}-journal"));
+        let _ = std::fs::remove_file(format!("{path}-wal"));
+        let _ = std::fs::remove_file(format!("{path}-shm"));
+    }
+
+    fn test_candle(ts_ms: i64, close: &str) -> Candle {
+        Candle {
+            ts_ms,
+            open: dec(close).unwrap(),
+            high: dec(close).unwrap(),
+            low: dec(close).unwrap(),
+            close: dec(close).unwrap(),
+            volume: Decimal::from_str("1").unwrap(),
+        }
+    }
+
+    /// Cross-contamination regression: identical `(coin, interval, ts)` rows under
+    /// two different `source` values must both survive, and each source's
+    /// `load_candles` must return only its own row — proving the composite
+    /// `(source, coin, interval, ts)` primary key actually isolates them.
+    #[tokio::test]
+    async fn candles_do_not_cross_contaminate_across_sources() {
+        let path = temp_db_path("cross_contam");
+        let cache = BacktestCache::open(&path).await.unwrap();
+
+        let interval = "1m";
+        let step = interval_ms(interval).unwrap();
+        let ts = 1_700_000_000_000i64;
+        // One interval-step-wide window so a single cached row already satisfies
+        // the coverage check (expected == 1) and load_candles never calls fetch.
+        let start_ms = ts;
+        let end_ms = ts + step;
+
+        cache
+            .upsert_candles("hyperliquid", "BTC", interval, end_ms, step, vec![test_candle(ts, "100")])
+            .await
+            .unwrap();
+        cache
+            .upsert_candles("binance", "BTC", interval, end_ms, step, vec![test_candle(ts, "200")])
+            .await
+            .unwrap();
+
+        let hl = PanicSource { sid: "hyperliquid", funding_hours: 1 };
+        let bn = PanicSource { sid: "binance", funding_hours: 8 };
+
+        let hl_rows = cache.load_candles(&hl, "BTC", interval, start_ms, end_ms).await.unwrap();
+        let bn_rows = cache.load_candles(&bn, "BTC", interval, start_ms, end_ms).await.unwrap();
+
+        assert_eq!(hl_rows.len(), 1);
+        assert_eq!(hl_rows[0].close, Decimal::from_str("100").unwrap());
+        assert_eq!(bn_rows.len(), 1);
+        assert_eq!(bn_rows[0].close, Decimal::from_str("200").unwrap());
+
+        cleanup_db(&path);
+    }
+
+    /// Legacy (pre-`source`-column) cache files must migrate their rows forward
+    /// tagged `source='hyperliquid'` (every pre-refactor row WAS fetched from
+    /// Hyperliquid), and a second `open()` on the already-migrated file must be a
+    /// no-op (idempotent — no duplication, no error).
+    #[tokio::test]
+    async fn legacy_schema_migrates_to_source_keyed_and_reopen_is_idempotent() {
+        let path = temp_db_path("legacy_migration");
+
+        // Build a legacy-schema DB by hand: no `source` column, exactly the
+        // pre-refactor primary key (coin, interval, ts).
+        {
+            let url = format!("sqlite://{}?mode=rwc", path);
+            let pool = SqlitePoolOptions::new().max_connections(1).connect(&url).await.unwrap();
+            sqlx::query(
+                "CREATE TABLE candles (
+                    coin TEXT NOT NULL, interval TEXT NOT NULL, ts INTEGER NOT NULL,
+                    o TEXT NOT NULL, h TEXT NOT NULL, l TEXT NOT NULL, c TEXT NOT NULL, v TEXT NOT NULL,
+                    PRIMARY KEY (coin, interval, ts)
+                )",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "INSERT INTO candles (coin, interval, ts, o, h, l, c, v)
+                 VALUES ('BTC','1m',1700000000000,'100','100','100','100','1')",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query(
+                "CREATE TABLE funding (
+                    coin TEXT NOT NULL, ts INTEGER NOT NULL, rate TEXT NOT NULL,
+                    PRIMARY KEY (coin, ts)
+                )",
+            )
+            .execute(&pool)
+            .await
+            .unwrap();
+            sqlx::query("INSERT INTO funding (coin, ts, rate) VALUES ('BTC',1700000000000,'0.0000125')")
+                .execute(&pool)
+                .await
+                .unwrap();
+            pool.close().await;
+        }
+
+        // First open() runs the migration.
+        let cache = BacktestCache::open(&path).await.unwrap();
+        let candle_row = sqlx::query("SELECT source, coin FROM candles WHERE coin='BTC'")
+            .fetch_one(cache.pool())
+            .await
+            .unwrap();
+        let source: String = candle_row.get("source");
+        assert_eq!(source, "hyperliquid");
+        let funding_row = sqlx::query("SELECT source FROM funding WHERE coin='BTC'")
+            .fetch_one(cache.pool())
+            .await
+            .unwrap();
+        let funding_source: String = funding_row.get("source");
+        assert_eq!(funding_source, "hyperliquid");
+        drop(cache);
+
+        // Second open() must be idempotent: no re-migration, no row duplication.
+        let cache2 = BacktestCache::open(&path).await.unwrap();
+        let n: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM candles WHERE coin='BTC'")
+            .fetch_one(cache2.pool())
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+        let nf: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM funding WHERE coin='BTC'")
+            .fetch_one(cache2.pool())
+            .await
+            .unwrap();
+        assert_eq!(nf, 1);
+
+        cleanup_db(&path);
+    }
+
+    /// `upsert_candles` must skip a candle whose bar has not yet closed
+    /// (`ts_ms + step > now_ms`) — persisting it would freeze a provisional OHLCV
+    /// value permanently under `INSERT OR IGNORE`, poisoning reruns.
+    #[tokio::test]
+    async fn upsert_candles_skips_still_forming_bar() {
+        let path = temp_db_path("still_forming");
+        let cache = BacktestCache::open(&path).await.unwrap();
+
+        let interval = "1m";
+        let step = interval_ms(interval).unwrap();
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+
+        // Closed bar: opened well over a step ago.
+        let closed = test_candle(now_ms - 10 * step, "111");
+        // Still forming: opened less than one step ago, so ts_ms + step > now_ms.
+        let forming = test_candle(now_ms - step / 2, "222");
+
+        cache
+            .upsert_candles(
+                "hyperliquid",
+                "BTC",
+                interval,
+                now_ms + 10 * step,
+                step,
+                vec![closed, forming],
+            )
+            .await
+            .unwrap();
+
+        let rows = sqlx::query("SELECT ts, c FROM candles WHERE source='hyperliquid' AND coin='BTC'")
+            .fetch_all(cache.pool())
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "only the closed bar should have been persisted");
+        let c: String = rows[0].get("c");
+        assert_eq!(c, "111");
+
+        cleanup_db(&path);
     }
 }

--- a/src/backtest/fetch.rs
+++ b/src/backtest/fetch.rs
@@ -1,0 +1,416 @@
+//! W2 — Historical data fetch + SQLite cache.
+//!
+//! Async fetchers against the public Hyperliquid Info API
+//! (`https://api.hyperliquid.xyz/info`) using plain `reqwest` 0.12 POSTs — the same
+//! wire shape `src/helpers/time.rs::fetch_hyperliquid_close` already uses, so no SDK
+//! and no `hyperliquid` cargo feature are required.
+//!
+//!   * `candleSnapshot` — 1m OHLCV. The endpoint caps each response at ~5000 candles,
+//!     so we paginate by advancing `startTime` past the last returned candle. Every
+//!     OHLCV field is a JSON STRING → parsed with `Decimal::from_str`. NOTE: the API
+//!     also RETAINS only the most recent ~5000 candles and anchors responses at the
+//!     TAIL, so a requested window older than ~5000×interval is head-truncated at the
+//!     source (unfetchable) — the harness detects this and warns; the still-forming
+//!     current candle is never cached (its OHLCV is provisional until the bar closes).
+//!   * `fundingHistory` — hourly funding series, paginated the same way.
+//!
+//! Results are cached in a SEPARATE SQLite file (default `backtest_cache.sqlite`,
+//! `--cache <path>`), with its OWN pool/schema — the live trading DB is never touched.
+//! Fetches fill gaps only: a range already densely cached is served from disk with no
+//! network round-trip. Pages are rate-limited (~200ms) to stay polite.
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use rust_decimal::Decimal;
+use sqlx::{sqlite::SqlitePoolOptions, Row, SqlitePool};
+use tracing::{debug, info};
+
+/// One OHLCV bar. Timestamps are the candle OPEN time in unix milliseconds (UTC).
+#[derive(Debug, Clone)]
+pub struct Candle {
+    pub ts_ms: i64,
+    pub open: Decimal,
+    pub high: Decimal,
+    pub low: Decimal,
+    pub close: Decimal,
+    pub volume: Decimal,
+}
+
+/// One funding observation: the HL HOURLY funding rate at `ts_ms` (UTC millis).
+/// Normalization to Binance's per-8h scale (×8) happens in `synth`, not here — we
+/// cache the raw rate exactly as the API returned it.
+#[derive(Debug, Clone)]
+pub struct FundingPoint {
+    pub ts_ms: i64,
+    pub rate: Decimal,
+}
+
+const INFO_URL: &str = "https://api.hyperliquid.xyz/info";
+const PAGE_DELAY: Duration = Duration::from_millis(200);
+/// Interval step in ms for the 1m default (used for coverage/gap checks).
+fn interval_ms(interval: &str) -> i64 {
+    match interval {
+        "1m" => 60_000,
+        "3m" => 180_000,
+        "5m" => 300_000,
+        "15m" => 900_000,
+        "30m" => 1_800_000,
+        "1h" => 3_600_000,
+        "4h" => 14_400_000,
+        "1d" => 86_400_000,
+        _ => 60_000,
+    }
+}
+
+/// Backtest-only SQLite cache. Distinct pool + schema from `helpers::db` — never
+/// shares the live trading database.
+pub struct BacktestCache {
+    pool: SqlitePool,
+}
+
+impl BacktestCache {
+    /// Open (creating if absent) the cache DB at `path` and ensure the schema.
+    pub async fn open(path: &str) -> Result<Self> {
+        let url = format!("sqlite://{}?mode=rwc", path);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect(&url)
+            .await
+            .with_context(|| format!("opening backtest cache at {path}"))?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS candles (
+                coin     TEXT NOT NULL,
+                interval TEXT NOT NULL,
+                ts       INTEGER NOT NULL,
+                o        TEXT NOT NULL,
+                h        TEXT NOT NULL,
+                l        TEXT NOT NULL,
+                c        TEXT NOT NULL,
+                v        TEXT NOT NULL,
+                PRIMARY KEY (coin, interval, ts)
+            )",
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS funding (
+                coin TEXT NOT NULL,
+                ts   INTEGER NOT NULL,
+                rate TEXT NOT NULL,
+                PRIMARY KEY (coin, ts)
+            )",
+        )
+        .execute(&pool)
+        .await?;
+
+        info!("📦 Backtest cache ready: {path}");
+        Ok(Self { pool })
+    }
+
+    /// Handle to the underlying pool so the LLM-score cache can share this DB file.
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
+    // ── Candles ───────────────────────────────────────────────────────────────
+
+    /// Load candles for `[start_ms, end_ms)`, fetching from Hyperliquid only for the
+    /// portion of the range not already densely cached. Returns them sorted ascending.
+    pub async fn load_candles(
+        &self,
+        http: &reqwest::Client,
+        coin: &str,
+        interval: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<Vec<Candle>> {
+        let step = interval_ms(interval);
+        let expected = ((end_ms - start_ms) / step).max(1);
+
+        let row = sqlx::query(
+            "SELECT COUNT(*) AS n, MIN(ts) AS lo, MAX(ts) AS hi
+             FROM candles WHERE coin=? AND interval=? AND ts>=? AND ts<?",
+        )
+        .bind(coin)
+        .bind(interval)
+        .bind(start_ms)
+        .bind(end_ms)
+        .fetch_one(&self.pool)
+        .await?;
+        let n: i64 = row.get("n");
+        let lo: Option<i64> = row.try_get("lo").ok();
+        let hi: Option<i64> = row.try_get("hi").ok();
+
+        let covered = n > 0
+            && lo.map(|l| l <= start_ms + 2 * step).unwrap_or(false)
+            && hi.map(|h| h >= end_ms - 2 * step).unwrap_or(false)
+            && n as f64 >= expected as f64 * 0.90;
+
+        if covered {
+            debug!("🗃️  candles [{coin} {interval}] served from cache ({n} rows)");
+        } else {
+            info!("🌐 fetching candles [{coin} {interval}] {start_ms}..{end_ms} (cache had {n})");
+            self.fetch_candles_range(http, coin, interval, start_ms, end_ms).await?;
+        }
+
+        let rows = sqlx::query(
+            "SELECT ts, o, h, l, c, v FROM candles
+             WHERE coin=? AND interval=? AND ts>=? AND ts<? ORDER BY ts ASC",
+        )
+        .bind(coin)
+        .bind(interval)
+        .bind(start_ms)
+        .bind(end_ms)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(Candle {
+                ts_ms: r.get::<i64, _>("ts"),
+                open: dec(r.get::<String, _>("o"))?,
+                high: dec(r.get::<String, _>("h"))?,
+                low: dec(r.get::<String, _>("l"))?,
+                close: dec(r.get::<String, _>("c"))?,
+                volume: dec(r.get::<String, _>("v"))?,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Paginated `candleSnapshot` fetch, upserting each page (INSERT OR IGNORE).
+    async fn fetch_candles_range(
+        &self,
+        http: &reqwest::Client,
+        coin: &str,
+        interval: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<()> {
+        let step = interval_ms(interval);
+        // Wall-clock now, to reject the currently-forming candle (see the `t + step`
+        // check below): its provisional OHLCV keeps moving until the interval closes,
+        // and `INSERT OR IGNORE` would cache those partial values PERMANENTLY, making
+        // reruns non-reproducible against the final bar.
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(i64::MAX);
+        let mut cursor = start_ms;
+        let mut total = 0usize;
+        while cursor < end_ms {
+            let body = serde_json::json!({
+                "type": "candleSnapshot",
+                "req": { "coin": coin, "interval": interval, "startTime": cursor, "endTime": end_ms }
+            });
+            let json: serde_json::Value = http
+                .post(INFO_URL)
+                .json(&body)
+                .send()
+                .await
+                .context("candleSnapshot POST failed")?
+                .json()
+                .await
+                .context("candleSnapshot decode failed")?;
+            let arr = json.as_array().cloned().unwrap_or_default();
+            if arr.is_empty() {
+                break;
+            }
+            let mut max_t = cursor;
+            let mut tx = self.pool.begin().await?;
+            for c in &arr {
+                let (Some(t), Some(o), Some(h), Some(l), Some(cl), Some(v)) = (
+                    c.get("t").and_then(|x| x.as_i64()),
+                    c.get("o").and_then(|x| x.as_str()),
+                    c.get("h").and_then(|x| x.as_str()),
+                    c.get("l").and_then(|x| x.as_str()),
+                    c.get("c").and_then(|x| x.as_str()),
+                    c.get("v").and_then(|x| x.as_str()),
+                ) else {
+                    continue;
+                };
+                if t >= end_ms {
+                    continue;
+                }
+                // Skip the still-forming candle for the current interval: it closes at
+                // `t + step`, so if that is in the future its OHLCV is provisional and
+                // must never be cached (would be frozen by INSERT OR IGNORE forever).
+                if t + step > now_ms {
+                    continue;
+                }
+                max_t = max_t.max(t);
+                sqlx::query(
+                    "INSERT OR IGNORE INTO candles (coin,interval,ts,o,h,l,c,v)
+                     VALUES (?,?,?,?,?,?,?,?)",
+                )
+                .bind(coin)
+                .bind(interval)
+                .bind(t)
+                .bind(o)
+                .bind(h)
+                .bind(l)
+                .bind(cl)
+                .bind(v)
+                .execute(&mut *tx)
+                .await?;
+                total += 1;
+            }
+            tx.commit().await?;
+
+            // Advance past the last candle we saw; guarantee forward progress.
+            let next = max_t + step;
+            if next <= cursor {
+                break;
+            }
+            cursor = next;
+            // Stop once a short page (< cap) tells us we reached the tail.
+            if arr.len() < 4000 {
+                break;
+            }
+            tokio::time::sleep(PAGE_DELAY).await;
+        }
+        info!("✅ candles fetched/cached: {total} rows [{coin} {interval}]");
+        Ok(())
+    }
+
+    // ── Funding ───────────────────────────────────────────────────────────────
+
+    /// Load the funding series for `[start_ms, end_ms)`, fetching from Hyperliquid
+    /// only when the cached range does not already cover it. Sorted ascending.
+    pub async fn load_funding(
+        &self,
+        http: &reqwest::Client,
+        coin: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<Vec<FundingPoint>> {
+        let hour = 3_600_000i64;
+        let row = sqlx::query(
+            "SELECT COUNT(*) AS n, MIN(ts) AS lo, MAX(ts) AS hi
+             FROM funding WHERE coin=? AND ts>=? AND ts<?",
+        )
+        .bind(coin)
+        .bind(start_ms)
+        .bind(end_ms)
+        .fetch_one(&self.pool)
+        .await?;
+        let n: i64 = row.get("n");
+        let lo: Option<i64> = row.try_get("lo").ok();
+        let hi: Option<i64> = row.try_get("hi").ok();
+        let covered = n > 0
+            && lo.map(|l| l <= start_ms + 2 * hour).unwrap_or(false)
+            && hi.map(|h| h >= end_ms - 2 * hour).unwrap_or(false);
+
+        if covered {
+            debug!("🗃️  funding [{coin}] served from cache ({n} rows)");
+        } else {
+            info!("🌐 fetching funding [{coin}] {start_ms}..{end_ms} (cache had {n})");
+            self.fetch_funding_range(http, coin, start_ms, end_ms).await?;
+        }
+
+        let rows = sqlx::query(
+            "SELECT ts, rate FROM funding WHERE coin=? AND ts>=? AND ts<? ORDER BY ts ASC",
+        )
+        .bind(coin)
+        .bind(start_ms)
+        .bind(end_ms)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for r in rows {
+            out.push(FundingPoint {
+                ts_ms: r.get::<i64, _>("ts"),
+                rate: dec(r.get::<String, _>("rate"))?,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn fetch_funding_range(
+        &self,
+        http: &reqwest::Client,
+        coin: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<()> {
+        let mut cursor = start_ms;
+        let mut total = 0usize;
+        while cursor < end_ms {
+            let body = serde_json::json!({
+                "type": "fundingHistory", "coin": coin, "startTime": cursor, "endTime": end_ms
+            });
+            let json: serde_json::Value = http
+                .post(INFO_URL)
+                .json(&body)
+                .send()
+                .await
+                .context("fundingHistory POST failed")?
+                .json()
+                .await
+                .context("fundingHistory decode failed")?;
+            let arr = json.as_array().cloned().unwrap_or_default();
+            if arr.is_empty() {
+                break;
+            }
+            let mut max_t = cursor;
+            let mut tx = self.pool.begin().await?;
+            for f in &arr {
+                let (Some(t), Some(rate)) = (
+                    f.get("time").and_then(|x| x.as_i64()),
+                    f.get("fundingRate").and_then(|x| x.as_str()),
+                ) else {
+                    continue;
+                };
+                if t >= end_ms {
+                    continue;
+                }
+                max_t = max_t.max(t);
+                sqlx::query("INSERT OR IGNORE INTO funding (coin,ts,rate) VALUES (?,?,?)")
+                    .bind(coin)
+                    .bind(t)
+                    .bind(rate)
+                    .execute(&mut *tx)
+                    .await?;
+                total += 1;
+            }
+            tx.commit().await?;
+            let next = max_t + 1;
+            if next <= cursor {
+                break;
+            }
+            cursor = next;
+            if arr.len() < 400 {
+                break;
+            }
+            tokio::time::sleep(PAGE_DELAY).await;
+        }
+        info!("✅ funding fetched/cached: {total} rows [{coin}]");
+        Ok(())
+    }
+}
+
+fn dec(s: String) -> Result<Decimal> {
+    Decimal::from_str(s.trim()).with_context(|| format!("parsing decimal from '{s}'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interval_ms_known_values() {
+        assert_eq!(interval_ms("1m"), 60_000);
+        assert_eq!(interval_ms("1h"), 3_600_000);
+        assert_eq!(interval_ms("weird"), 60_000); // graceful default
+    }
+
+    #[test]
+    fn dec_parses_string_ohlcv() {
+        assert_eq!(dec("42055.5".to_string()).unwrap(), Decimal::from_str("42055.5").unwrap());
+        assert!(dec("not-a-number".to_string()).is_err());
+    }
+}

--- a/src/backtest/harness.rs
+++ b/src/backtest/harness.rs
@@ -1,0 +1,594 @@
+//! W5 — Replay harness: drives the REAL vipers over synthetic hourly markets and
+//! books every fill into the authoritative Decimal ledger.
+//!
+//! Per replay tick (one 1m candle) the harness:
+//!   1. rolls to the active synthetic hourly market (close = top of the next hour,
+//!      strike = the oracle at the hour open — the same reference the production
+//!      strike derivation in `helpers::time` uses), settling the prior market's open
+//!      legs at 0/1 on rotation;
+//!   2. synthesizes a `MarketSnapshot` (`synth`), builds a `StrategyContext` with the
+//!      W1 clock seam set to HISTORICAL time (`wall_now`/`mono_now` from `ReplayClock`),
+//!      a harness-owned `Arc<Mutex<PositionMap>>`, a `DynamicConfig` with the selected
+//!      strategy enable flags, and `session_pnl` from the ledger;
+//!   3. calls `evaluate_exit` then `evaluate_entry` on every viper (exits prioritised,
+//!      mirroring `executor`/`patrol`), filling entries at the modeled ask (capped by
+//!      modeled depth) and exits at the modeled bid;
+//!   4. records the per-candle net directional stance for the rs-backtester proxy.
+//!
+//! No CLOB client, wallet, or live DB pool is required — TrendReversal's SQLite
+//! cascade guard harmlessly no-ops when no pool is registered.
+
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use tokio::sync::Mutex;
+use tracing::info;
+
+use crate::helpers::dynamic_config::DynamicConfig;
+use crate::helpers::paper::binary_settlement_payout;
+use crate::orchestrator::{StrategyContext, StrategyRegistry};
+use crate::state::{MarketConfig, MarketSnapshot, OrderParams, Position, PositionMap, StrategySignal};
+use crate::venues::core::{MarketId, TimeInForce};
+
+use super::bridge::Stance;
+use super::clock::ReplayClock;
+use super::fetch::{BacktestCache, Candle, FundingPoint};
+use super::ledger::{ClosedTrade, CloseKind, Ledger};
+use super::llm_score::{LlmScorer, ScoredEntry};
+use super::synth::SnapshotSynthesizer;
+
+const HOUR_MS: i64 = 3_600_000;
+
+/// Fully-resolved backtest parameters (from the CLI).
+pub struct BacktestConfig {
+    /// Hyperliquid coin symbol, e.g. "BTC".
+    pub coin: String,
+    /// Lowercase asset used for `ctx.crypto_filter` (BTC-only gates read this).
+    pub crypto_filter: String,
+    pub interval: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    /// `None` → all vipers enabled; `Some(list)` → only those (by short name).
+    pub strategies: Option<Vec<String>>,
+    pub half_spread: Decimal,
+    pub depth: Decimal,
+    pub commission: Decimal,
+    pub starting_collateral: Decimal,
+    pub llm_score: bool,
+    pub cache_path: String,
+    pub out_dir: String,
+    pub sigma_window: usize,
+}
+
+/// Everything `report` needs after a run.
+pub struct BacktestOutcome {
+    pub ledger: Ledger,
+    /// Per-candle net directional stance (aligned 1:1 with `candles`) for the proxy.
+    pub stances: Vec<Stance>,
+    pub candles: Vec<Candle>,
+    pub scored_entries: Vec<ScoredEntry>,
+    pub ticks: usize,
+    pub markets: usize,
+}
+
+/// The market currently active during the replay.
+struct ActiveMarket {
+    open_ms: i64,
+    close_wall: DateTime<Utc>,
+    strike: Option<Decimal>,
+    yes_token: MarketId,
+    no_token: MarketId,
+    config: MarketConfig,
+    started_at: DateTime<Utc>,
+}
+
+/// Apply the `--strategies` selection to a `DynamicConfig`.
+fn configure_enables(dc: &mut DynamicConfig, sel: &Option<Vec<String>>) {
+    let all = sel.is_none();
+    let set = |name: &str| -> bool {
+        match sel {
+            None => true,
+            Some(list) => list.iter().any(|s| {
+                let s = s.trim().to_ascii_lowercase();
+                s == name
+            }),
+        }
+    };
+    dc.enable_momentum = all || set("momentum");
+    dc.enable_arbitrage = all || set("arbitrage");
+    dc.enable_time_decay = all || set("timedecay") || set("time_decay");
+    dc.enable_maker = all || set("maker");
+    dc.enable_basis = all || set("basis");
+    dc.enable_gboost = all || set("gboost");
+    dc.enable_trendcapture = all || set("trendreversal") || set("trendcapture");
+    dc.enable_convergence = all || set("convergence");
+    // Backtest fills are modeled, never placed — mark orders ghost for correctness.
+    dc.ghost_mode = true;
+}
+
+/// Latest funding rate at or before `ts_ms` (raw HL hourly rate; 0 if none yet).
+fn funding_at(funding: &[FundingPoint], ts_ms: i64) -> Decimal {
+    match funding.binary_search_by(|f| f.ts_ms.cmp(&ts_ms)) {
+        Ok(i) => funding[i].rate,
+        Err(0) => dec!(0),
+        Err(i) => funding[i - 1].rate,
+    }
+}
+
+pub async fn run_backtest(cfg: &BacktestConfig) -> Result<BacktestOutcome> {
+    let cache = BacktestCache::open(&cfg.cache_path).await?;
+    let http = reqwest::Client::new();
+
+    let candles = cache
+        .load_candles(&http, &cfg.coin, &cfg.interval, cfg.start_ms, cfg.end_ms)
+        .await?;
+    if candles.len() < 2 {
+        bail!(
+            "not enough candles for {} {} in [{}, {}) — got {}",
+            cfg.coin,
+            cfg.interval,
+            cfg.start_ms,
+            cfg.end_ms,
+            candles.len()
+        );
+    }
+    // ── Coverage check ──────────────────────────────────────────────────────
+    // Hyperliquid retains ONLY the most recent ~5000 candles and anchors every
+    // candleSnapshot response at the TAIL, so a window older than ~5000×interval is
+    // silently head-truncated (the fetch can never fill the missing head — it is
+    // purged server-side). Warn loudly when the replayed range does not cover the
+    // request; `report.json` records both the requested and the actual replayed range.
+    let step_ms = (candles[1].ts_ms - candles[0].ts_ms).max(1);
+    let first_ms = candles[0].ts_ms;
+    let last_ms = candles.last().unwrap().ts_ms;
+    let head_gap = first_ms - cfg.start_ms;
+    let tail_gap = cfg.end_ms - (last_ms + step_ms);
+    if head_gap > 2 * step_ms || tail_gap > 2 * step_ms {
+        tracing::warn!(
+            "⚠️  requested [{}, {}) but replay only covers [{}, {}]: ~{} min head / ~{} min tail \
+             uncovered. Hyperliquid retains only the most recent ~5000 candles and anchors \
+             responses at the tail, so windows older than ~5000×interval are truncated. The \
+             summary/report start/end reflect the REQUEST; see replayed_start_ms/replayed_end_ms \
+             for what was actually replayed.",
+            cfg.start_ms, cfg.end_ms, first_ms, last_ms,
+            head_gap.max(0) / 60_000, tail_gap.max(0) / 60_000,
+        );
+    }
+
+    let funding = cache
+        .load_funding(&http, &cfg.coin, cfg.start_ms, cfg.end_ms)
+        .await?;
+    info!(
+        "▶️  replay: {} candles, {} funding points [{}]",
+        candles.len(),
+        funding.len(),
+        cfg.coin
+    );
+
+    // Price lookup: greatest candle close with ts <= query (nearest-prior).
+    let ts_sorted: Vec<i64> = candles.iter().map(|c| c.ts_ms).collect();
+    let price_at_or_before = |ts: i64| -> Option<Decimal> {
+        match ts_sorted.binary_search(&ts) {
+            Ok(i) => Some(candles[i].close),
+            Err(0) => None,
+            Err(i) => Some(candles[i - 1].close),
+        }
+    };
+
+    let clock = ReplayClock::new(candles[0].ts_ms);
+    let mut synth = SnapshotSynthesizer::new(cfg.half_spread, cfg.depth, cfg.sigma_window);
+    let mut ledger = Ledger::new(cfg.starting_collateral);
+    let positions: Arc<Mutex<PositionMap>> = Arc::new(Mutex::new(PositionMap::new()));
+
+    let mut base_dc = DynamicConfig::default();
+    configure_enables(&mut base_dc, &cfg.strategies);
+    let dc = Arc::new(base_dc);
+
+    let strategies = StrategyRegistry::create_all_strategies();
+
+    // Optional experimental LLM decision scorer (shares the cache DB).
+    let mut scorer = if cfg.llm_score {
+        match LlmScorer::new(cache.pool().clone()).await {
+            Ok(s) => Some(s),
+            Err(e) => {
+                info!("🤖 LLM scoring disabled: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let mut scored_entries: Vec<ScoredEntry> = Vec::new();
+
+    let mut cur: Option<ActiveMarket> = None;
+    let mut stances: Vec<Stance> = Vec::with_capacity(candles.len());
+    let mut markets_seen = 0usize;
+
+    for candle in &candles {
+        let ts = candle.ts_ms;
+        let open_ms = (ts / HOUR_MS) * HOUR_MS;
+
+        // ── Rotate market on hour boundary (settle the prior market first) ──────
+        if cur.as_ref().map(|m| m.open_ms) != Some(open_ms) {
+            if let Some(prev) = cur.take() {
+                settle_market(&prev, &price_at_or_before, &positions, &mut ledger, cfg.commission).await;
+            }
+            let close_ms = open_ms + HOUR_MS;
+            let close_wall = clock.wall(close_ms);
+            let strike = price_at_or_before(open_ms);
+            let yes_token = MarketId::new(format!("{}-{}-YES", cfg.coin, open_ms));
+            let no_token = MarketId::new(format!("{}-{}-NO", cfg.coin, open_ms));
+            let condition_id = format!("{}-{}", cfg.coin, open_ms);
+            let market_name = format!("{} Up or Down (bt {})", cfg.coin, clock.wall(open_ms));
+            let config = MarketConfig {
+                yes_token: yes_token.clone(),
+                no_token: no_token.clone(),
+                market_name,
+                market_close_time: Some(close_wall),
+                strike_price: strike,
+                is_neg_risk: false,
+                condition_id,
+                yes_fee_bps: 0,
+                no_fee_bps: 0,
+            };
+            cur = Some(ActiveMarket {
+                open_ms,
+                close_wall,
+                strike,
+                yes_token,
+                no_token,
+                config,
+                started_at: clock.wall(open_ms),
+            });
+            markets_seen += 1;
+        }
+        let market = cur.as_ref().unwrap();
+
+        // ── Synthesize snapshot + context ───────────────────────────────────────
+        let funding_rate = funding_at(&funding, ts);
+        let snapshot = synth.on_tick(&clock, candle, market.close_wall, market.strike, funding_rate);
+        let realized = ledger.realized();
+        let ctx = StrategyContext {
+            market: market.config.clone(),
+            snapshot: snapshot.clone(),
+            positions: Arc::clone(&positions),
+            session_pnl: realized,
+            starting_collateral: cfg.starting_collateral,
+            crypto_filter: cfg.crypto_filter.clone(),
+            market_started_at: market.started_at,
+            maker_market: None,
+            maker_snapshot: None,
+            available_collateral: cfg.starting_collateral + realized,
+            dynamic_config: Arc::clone(&dc),
+            arb_market_lockouts: None,
+            wall_now: clock.wall(ts),
+            mono_now: clock.mono_std(ts),
+            // Replay run — vipers must NOT consult the live bot's persistent SQLite
+            // state (e.g. TrendReversal's cascade guard). See StrategyContext::is_replay.
+            is_replay: true,
+        };
+
+        // ── Exits first, then entries (mirror executor priority) ────────────────
+        for strat in &strategies {
+            if let Ok(sig) = strat.evaluate_exit(&ctx).await {
+                apply_exit(&strat.name(), &sig, &snapshot, market, &positions, &mut ledger, cfg.commission).await;
+            }
+        }
+        for strat in &strategies {
+            if let Ok(sig) = strat.evaluate_entry(&ctx).await {
+                apply_entry(
+                    &strat.name(),
+                    &sig,
+                    &snapshot,
+                    market,
+                    &positions,
+                    ctx.wall_now,
+                    cfg.commission,
+                    scorer.as_mut(),
+                    &mut scored_entries,
+                )
+                .await;
+            }
+        }
+
+        // ── Equity curve + rs-backtester stance ─────────────────────────────────
+        let (unrealized, stance) = mark_positions(&positions, &snapshot, market).await;
+        ledger.push_equity(clock.wall(ts), unrealized);
+        stances.push(stance);
+    }
+
+    // Settle the final open market at the last candle's close.
+    if let Some(prev) = cur.take() {
+        settle_market(&prev, &price_at_or_before, &positions, &mut ledger, cfg.commission).await;
+    }
+
+    // Attach realized outcomes to any LLM-scored entries.
+    join_scores(&mut scored_entries, &ledger);
+
+    Ok(BacktestOutcome {
+        ledger,
+        stances,
+        candles: candles.clone(),
+        scored_entries,
+        ticks: candles.len(),
+        markets: markets_seen,
+    })
+}
+
+/// Resolve which side (`Some(true)`=YES / `Some(false)`=NO) a token trades, on the
+/// active synthetic market.
+fn side_of(token: &MarketId, m: &ActiveMarket) -> Option<bool> {
+    if token == &m.yes_token {
+        Some(true)
+    } else if token == &m.no_token {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Fill one entry leg at the modeled ask (capped by modeled depth), updating the
+/// position map. Optionally scores the decision with the LLM.
+#[allow(clippy::too_many_arguments)]
+async fn apply_entry(
+    strategy: &str,
+    sig: &StrategySignal,
+    snap: &MarketSnapshot,
+    m: &ActiveMarket,
+    positions: &Arc<Mutex<PositionMap>>,
+    wall_now: DateTime<Utc>,
+    commission: Decimal,
+    scorer: Option<&mut LlmScorer>,
+    scored: &mut Vec<ScoredEntry>,
+) {
+    let StrategySignal::Entry { params, pair_params } = sig else {
+        return;
+    };
+    let mut legs: Vec<&OrderParams> = vec![params];
+    if let Some(p) = pair_params {
+        legs.push(p);
+    }
+
+    // LLM scoring: one score per Entry signal, keyed to the primary leg.
+    if let Some(sc) = scorer {
+        if let Some(is_yes) = side_of(&params.token_id, m) {
+            if let Some(entry) = sc
+                .score_entry(strategy, is_yes, wall_now, snap, params)
+                .await
+            {
+                scored.push(entry);
+            }
+        }
+    }
+
+    let mut map = positions.lock().await;
+    for leg in legs {
+        let Some(is_yes) = side_of(&leg.token_id, m) else {
+            continue;
+        };
+        // Honor the order's resting semantics. A `post_only` / GTC-GTD limit is a
+        // resting MAKER bid: it fills at its OWN posted limit price when that price
+        // sits at/above the modeled best bid (it would be the front of the book and
+        // get hit) — filling it at the ask like a taker inverts maker economics
+        // (e.g. TimeDecay's 1−(yes_bid+no_bid) edge would flip to a guaranteed loss).
+        // Everything else (FAK/FOK, or a crossing limit) is a taker and fills at the ask.
+        let is_maker =
+            leg.post_only || matches!(leg.order_type, TimeInForce::Gtc | TimeInForce::Gtd);
+        let (fill_price, depth) = if is_maker {
+            let (bid, bid_depth) = if is_yes {
+                (snap.yes_bid, snap.yes_bid_depth)
+            } else {
+                (snap.no_bid, snap.no_bid_depth)
+            };
+            // Limit below the best bid would not be hit this tick — no fill.
+            if leg.price < bid {
+                continue;
+            }
+            (leg.price, bid_depth)
+        } else if is_yes {
+            (snap.yes_ask, snap.yes_ask_depth)
+        } else {
+            (snap.no_ask, snap.no_ask_depth)
+        };
+        if fill_price <= dec!(0) {
+            continue;
+        }
+        let fill = leg.shares.min(depth);
+        if fill <= dec!(0) {
+            continue;
+        }
+        let key = (strategy.to_string(), leg.token_id.clone());
+        let entry = map.entry(key).or_insert_with(|| Position {
+            shares: dec!(0),
+            avg_entry: fill_price,
+            opened_at: wall_now,
+            close_time: m.config.market_close_time,
+            market_name: m.config.market_name.clone(),
+            pair_token_id: leg.token_id.clone(),
+            // Fills are deterministic in replay — confirm immediately so exit gates engage.
+            fill_confirmed_at: Some(wall_now),
+            paired_leg_token_id: None,
+            ghost: true,
+        });
+        let new_shares = entry.shares + fill;
+        if new_shares > dec!(0) {
+            entry.avg_entry = (entry.avg_entry * entry.shares + fill_price * fill) / new_shares;
+        }
+        entry.shares = new_shares;
+    }
+    let _ = commission; // entry-side fee folded into exit/settlement PnL below.
+}
+
+/// Fill an exit at the modeled bid; on `exit_pair`, also close the strategy's other
+/// leg on this market.
+async fn apply_exit(
+    strategy: &str,
+    sig: &StrategySignal,
+    snap: &MarketSnapshot,
+    m: &ActiveMarket,
+    positions: &Arc<Mutex<PositionMap>>,
+    ledger: &mut Ledger,
+    commission: Decimal,
+) {
+    let StrategySignal::Exit { params, reason, exit_pair } = sig else {
+        return;
+    };
+    let mut tokens: Vec<MarketId> = vec![params.token_id.clone()];
+    if *exit_pair {
+        // Close both legs of the pair for this strategy on this market.
+        for t in [&m.yes_token, &m.no_token] {
+            if !tokens.contains(t) {
+                tokens.push(t.clone());
+            }
+        }
+    }
+
+    let mut map = positions.lock().await;
+    for token in tokens {
+        let Some(is_yes) = side_of(&token, m) else {
+            continue;
+        };
+        let bid = if is_yes { snap.yes_bid } else { snap.no_bid };
+        let bid_depth = if is_yes { snap.yes_bid_depth } else { snap.no_bid_depth };
+        let key = (strategy.to_string(), token.clone());
+        let Some(pos) = map.get(&key).cloned() else {
+            continue;
+        };
+        if pos.shares <= dec!(0) {
+            continue;
+        }
+        // Vipers request a full-position exit; cap the fill by modeled bid depth.
+        let sell = pos.shares.min(bid_depth);
+        if sell <= dec!(0) {
+            continue;
+        }
+        let fees = (pos.avg_entry + bid) * sell * commission;
+        let pnl = (bid - pos.avg_entry) * sell - fees;
+        ledger.record_close(ClosedTrade {
+            strategy: strategy.to_string(),
+            side: if is_yes { "YES" } else { "NO" }.to_string(),
+            kind: CloseKind::Exit,
+            entry_ts: pos.opened_at,
+            exit_ts: snap.timestamp,
+            entry_price: pos.avg_entry,
+            exit_price: bid,
+            shares: sell,
+            pnl,
+            reason: reason.clone(),
+        });
+        if sell >= pos.shares {
+            map.remove(&key);
+        } else if let Some(p) = map.get_mut(&key) {
+            p.shares -= sell;
+        }
+    }
+}
+
+/// Settle every open leg of a closing market at 0/1 vs strike.
+async fn settle_market<F>(
+    m: &ActiveMarket,
+    price_at_or_before: &F,
+    positions: &Arc<Mutex<PositionMap>>,
+    ledger: &mut Ledger,
+    commission: Decimal,
+) where
+    F: Fn(i64) -> Option<Decimal>,
+{
+    let close_ms = m.open_ms + HOUR_MS;
+    let settle_price = match price_at_or_before(close_ms) {
+        Some(p) => p,
+        None => return,
+    };
+    let strike = m.strike;
+    let mut map = positions.lock().await;
+    let keys: Vec<(String, MarketId)> = map
+        .keys()
+        .filter(|(_, t)| t == &m.yes_token || t == &m.no_token)
+        .cloned()
+        .collect();
+    for key in keys {
+        let Some(pos) = map.remove(&key) else { continue };
+        if pos.shares <= dec!(0) {
+            continue;
+        }
+        let is_yes = key.1 == m.yes_token;
+        // Match the live paper-trading / viper convention exactly (helpers::paper):
+        // `oracle >= strike ⇒ YES wins` (a tie pays YES), and an UNKNOWN strike is
+        // unresolvable so BOTH sides pay $0 — never a free NO win.
+        let payout = binary_settlement_payout(is_yes, settle_price, strike);
+        // Charge the entry-side fee deferred by `apply_entry` (redemption itself is
+        // fee-free on Polymarket), so settlement-closed legs are not silently cheaper
+        // than exit-closed legs under a nonzero `--commission`.
+        let fees = pos.avg_entry * pos.shares * commission;
+        let pnl = (payout - pos.avg_entry) * pos.shares - fees;
+        ledger.record_close(ClosedTrade {
+            strategy: key.0.clone(),
+            side: if is_yes { "YES" } else { "NO" }.to_string(),
+            kind: CloseKind::Settlement,
+            entry_ts: pos.opened_at,
+            exit_ts: m.close_wall,
+            entry_price: pos.avg_entry,
+            exit_price: payout,
+            shares: pos.shares,
+            pnl,
+            reason: format!("Settlement (final=${} strike={:?})", settle_price, strike),
+        });
+    }
+}
+
+/// Mark-to-market open positions on the active market: returns (unrealized PnL,
+/// net directional stance for the rs-backtester proxy).
+async fn mark_positions(
+    positions: &Arc<Mutex<PositionMap>>,
+    snap: &MarketSnapshot,
+    m: &ActiveMarket,
+) -> (Decimal, Stance) {
+    let map = positions.lock().await;
+    let mut unrealized = dec!(0);
+    let mut yes_notional = dec!(0);
+    let mut no_notional = dec!(0);
+    for ((_, token), pos) in map.iter() {
+        let Some(is_yes) = side_of(token, m) else { continue };
+        let bid = if is_yes { snap.yes_bid } else { snap.no_bid };
+        unrealized += (bid - pos.avg_entry) * pos.shares;
+        let notional = pos.avg_entry * pos.shares;
+        if is_yes {
+            yes_notional += notional;
+        } else {
+            no_notional += notional;
+        }
+    }
+    let stance = if yes_notional > no_notional {
+        Stance::Long
+    } else if no_notional > yes_notional {
+        Stance::Short
+    } else {
+        Stance::Flat
+    };
+    (unrealized, stance)
+}
+
+/// Attach each scored entry's realized outcome by matching the nearest closed trade
+/// with the same strategy+side and entry timestamp.
+fn join_scores(scored: &mut [ScoredEntry], ledger: &Ledger) {
+    let closed = ledger.closed_trades();
+    for s in scored.iter_mut() {
+        let mut best: Option<(&ClosedTrade, i64)> = None;
+        for t in closed {
+            if t.strategy == s.strategy && t.side == s.side {
+                let dist = (t.entry_ts - s.entry_ts).num_seconds().abs();
+                if best.map(|(_, d)| dist < d).unwrap_or(true) {
+                    best = Some((t, dist));
+                }
+            }
+        }
+        if let Some((t, dist)) = best {
+            if dist <= 120 {
+                s.realized_pnl = Some(t.pnl);
+            }
+        }
+    }
+}

--- a/src/backtest/harness.rs
+++ b/src/backtest/harness.rs
@@ -38,13 +38,15 @@ use super::clock::ReplayClock;
 use super::fetch::{BacktestCache, Candle, FundingPoint};
 use super::ledger::{ClosedTrade, CloseKind, Ledger};
 use super::llm_score::{LlmScorer, ScoredEntry};
+use super::source::{build_source, SourceKind};
 use super::synth::SnapshotSynthesizer;
 
 const HOUR_MS: i64 = 3_600_000;
 
 /// Fully-resolved backtest parameters (from the CLI).
 pub struct BacktestConfig {
-    /// Hyperliquid coin symbol, e.g. "BTC".
+    /// DRADIS coin symbol, e.g. "BTC" — mapped to the provider's wire symbol by
+    /// the selected source.
     pub coin: String,
     /// Lowercase asset used for `ctx.crypto_filter` (BTC-only gates read this).
     pub crypto_filter: String,
@@ -61,6 +63,9 @@ pub struct BacktestConfig {
     pub cache_path: String,
     pub out_dir: String,
     pub sigma_window: usize,
+    /// Historical-data provider to replay from. Both providers hit public,
+    /// unauthenticated endpoints — no credentials involved.
+    pub source: SourceKind,
 }
 
 /// Everything `report` needs after a run.
@@ -109,7 +114,7 @@ fn configure_enables(dc: &mut DynamicConfig, sel: &Option<Vec<String>>) {
     dc.ghost_mode = true;
 }
 
-/// Latest funding rate at or before `ts_ms` (raw HL hourly rate; 0 if none yet).
+/// Latest funding rate at or before `ts_ms` (provider-native rate; 0 if none yet).
 fn funding_at(funding: &[FundingPoint], ts_ms: i64) -> Decimal {
     match funding.binary_search_by(|f| f.ts_ms.cmp(&ts_ms)) {
         Ok(i) => funding[i].rate,
@@ -120,10 +125,10 @@ fn funding_at(funding: &[FundingPoint], ts_ms: i64) -> Decimal {
 
 pub async fn run_backtest(cfg: &BacktestConfig) -> Result<BacktestOutcome> {
     let cache = BacktestCache::open(&cfg.cache_path).await?;
-    let http = reqwest::Client::new();
+    let source = build_source(cfg.source);
 
     let candles = cache
-        .load_candles(&http, &cfg.coin, &cfg.interval, cfg.start_ms, cfg.end_ms)
+        .load_candles(source.as_ref(), &cfg.coin, &cfg.interval, cfg.start_ms, cfg.end_ms)
         .await?;
     if candles.len() < 2 {
         bail!(
@@ -136,30 +141,35 @@ pub async fn run_backtest(cfg: &BacktestConfig) -> Result<BacktestOutcome> {
         );
     }
     // ── Coverage check ──────────────────────────────────────────────────────
-    // Hyperliquid retains ONLY the most recent ~5000 candles and anchors every
-    // candleSnapshot response at the TAIL, so a window older than ~5000×interval is
-    // silently head-truncated (the fetch can never fill the missing head — it is
-    // purged server-side). Warn loudly when the replayed range does not cover the
-    // request; `report.json` records both the requested and the actual replayed range.
+    // Warn loudly when the replayed range does not cover the request; `report.json`
+    // records both the requested and the actual replayed range. Hyperliquid retains
+    // ONLY the most recent ~5000 candles and anchors every candleSnapshot response
+    // at the TAIL, so a window older than ~5000×interval is silently head-truncated
+    // (the fetch can never fill the missing head — it is purged server-side); other
+    // sources may simply not have data that far back yet cached/fetched.
     let step_ms = (candles[1].ts_ms - candles[0].ts_ms).max(1);
     let first_ms = candles[0].ts_ms;
     let last_ms = candles.last().unwrap().ts_ms;
     let head_gap = first_ms - cfg.start_ms;
     let tail_gap = cfg.end_ms - (last_ms + step_ms);
     if head_gap > 2 * step_ms || tail_gap > 2 * step_ms {
+        let retention_note = if cfg.source == SourceKind::Hyperliquid {
+            " Hyperliquid retains only the most recent ~5000 candles and anchors responses at the \
+              tail, so windows older than ~5000×interval are truncated."
+        } else {
+            ""
+        };
         tracing::warn!(
             "⚠️  requested [{}, {}) but replay only covers [{}, {}]: ~{} min head / ~{} min tail \
-             uncovered. Hyperliquid retains only the most recent ~5000 candles and anchors \
-             responses at the tail, so windows older than ~5000×interval are truncated. The \
-             summary/report start/end reflect the REQUEST; see replayed_start_ms/replayed_end_ms \
-             for what was actually replayed.",
+             uncovered.{} The summary/report start/end reflect the REQUEST; see \
+             replayed_start_ms/replayed_end_ms for what was actually replayed.",
             cfg.start_ms, cfg.end_ms, first_ms, last_ms,
-            head_gap.max(0) / 60_000, tail_gap.max(0) / 60_000,
+            head_gap.max(0) / 60_000, tail_gap.max(0) / 60_000, retention_note,
         );
     }
 
     let funding = cache
-        .load_funding(&http, &cfg.coin, cfg.start_ms, cfg.end_ms)
+        .load_funding(source.as_ref(), &cfg.coin, cfg.start_ms, cfg.end_ms)
         .await?;
     info!(
         "▶️  replay: {} candles, {} funding points [{}]",
@@ -249,7 +259,14 @@ pub async fn run_backtest(cfg: &BacktestConfig) -> Result<BacktestOutcome> {
 
         // ── Synthesize snapshot + context ───────────────────────────────────────
         let funding_rate = funding_at(&funding, ts);
-        let snapshot = synth.on_tick(&clock, candle, market.close_wall, market.strike, funding_rate);
+        let snapshot = synth.on_tick(
+            &clock,
+            candle,
+            market.close_wall,
+            market.strike,
+            funding_rate,
+            source.funding_period_hours(),
+        );
         let realized = ledger.realized();
         let ctx = StrategyContext {
             market: market.config.clone(),

--- a/src/backtest/ledger.rs
+++ b/src/backtest/ledger.rs
@@ -1,0 +1,180 @@
+//! W5 — Authoritative Decimal ledger with binary settlement.
+//!
+//! This is the AUTHORITATIVE PnL view: it prices the actual binary YES/NO shares the
+//! vipers trade, settling each open leg at 0/1 against the strike at market close.
+//! (The rs-backtester run in `report` is a separate directional proxy.)
+//!
+//! Per-trade PnL is booked the same way the live bot books it
+//! (`pnl = (exit_price − avg_entry) × shares − fees`); the aggregate realized PnL is
+//! fed back into `ctx.session_pnl` each tick so drawdown gates see live P&L.
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// How a position was closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum CloseKind {
+    /// Strategy-emitted exit, filled at the modeled bid.
+    Exit,
+    /// Binary settlement at market close (0/1 vs strike).
+    Settlement,
+}
+
+/// One fully-closed trade (entry + exit or entry + settlement).
+#[derive(Debug, Clone, Serialize)]
+pub struct ClosedTrade {
+    pub strategy: String,
+    /// "YES" or "NO".
+    pub side: String,
+    pub kind: CloseKind,
+    pub entry_ts: DateTime<Utc>,
+    pub exit_ts: DateTime<Utc>,
+    pub entry_price: Decimal,
+    pub exit_price: Decimal,
+    pub shares: Decimal,
+    pub pnl: Decimal,
+    pub reason: String,
+}
+
+/// Per-strategy roll-up computed at report time.
+#[derive(Debug, Clone, Serialize)]
+pub struct StrategyStats {
+    pub strategy: String,
+    pub trades: usize,
+    pub wins: usize,
+    pub win_rate: f64,
+    pub pnl: Decimal,
+}
+
+/// Decimal-native ledger: records closed trades, tracks realized PnL, and samples an
+/// equity curve (starting + realized + current unrealized mark-to-market).
+pub struct Ledger {
+    starting: Decimal,
+    realized: Decimal,
+    closed: Vec<ClosedTrade>,
+    equity_curve: Vec<(DateTime<Utc>, Decimal)>,
+}
+
+impl Ledger {
+    pub fn new(starting: Decimal) -> Self {
+        Self {
+            starting,
+            realized: dec!(0),
+            closed: Vec::new(),
+            equity_curve: Vec::new(),
+        }
+    }
+
+    /// Record a closed trade and fold its PnL into the running realized total.
+    pub fn record_close(&mut self, trade: ClosedTrade) {
+        self.realized += trade.pnl;
+        self.closed.push(trade);
+    }
+
+    /// Sample the equity curve: `starting + realized + unrealized` at `ts`.
+    pub fn push_equity(&mut self, ts: DateTime<Utc>, unrealized: Decimal) {
+        self.equity_curve
+            .push((ts, self.starting + self.realized + unrealized));
+    }
+
+    /// Aggregate realized PnL — fed into `ctx.session_pnl` each tick.
+    pub fn realized(&self) -> Decimal {
+        self.realized
+    }
+
+    pub fn starting(&self) -> Decimal {
+        self.starting
+    }
+
+    pub fn closed_trades(&self) -> &[ClosedTrade] {
+        &self.closed
+    }
+
+    pub fn equity_curve(&self) -> &[(DateTime<Utc>, Decimal)] {
+        &self.equity_curve
+    }
+
+    /// Per-strategy roll-ups, sorted by strategy name.
+    pub fn per_strategy(&self) -> Vec<StrategyStats> {
+        let mut map: BTreeMap<String, (usize, usize, Decimal)> = BTreeMap::new();
+        for t in &self.closed {
+            let e = map.entry(t.strategy.clone()).or_insert((0, 0, dec!(0)));
+            e.0 += 1;
+            if t.pnl > dec!(0) {
+                e.1 += 1;
+            }
+            e.2 += t.pnl;
+        }
+        map.into_iter()
+            .map(|(strategy, (trades, wins, pnl))| StrategyStats {
+                strategy,
+                trades,
+                wins,
+                win_rate: if trades > 0 {
+                    wins as f64 / trades as f64
+                } else {
+                    0.0
+                },
+                pnl,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn trade(strategy: &str, side: &str, entry: &str, exit: &str, shares: &str, kind: CloseKind) -> ClosedTrade {
+        let entry_p = Decimal::from_str(entry).unwrap();
+        let exit_p = Decimal::from_str(exit).unwrap();
+        let sh = Decimal::from_str(shares).unwrap();
+        ClosedTrade {
+            strategy: strategy.into(),
+            side: side.into(),
+            kind,
+            entry_ts: Utc::now(),
+            exit_ts: Utc::now(),
+            entry_price: entry_p,
+            exit_price: exit_p,
+            shares: sh,
+            pnl: (exit_p - entry_p) * sh,
+            reason: "test".into(),
+        }
+    }
+
+    #[test]
+    fn settlement_math_yes_win_and_loss() {
+        let mut l = Ledger::new(dec!(500));
+        // YES bought at 0.40, settles at 1.0 → +0.60 * 100 = +60.
+        l.record_close(trade("Momentum", "YES", "0.40", "1.0", "100", CloseKind::Settlement));
+        // NO bought at 0.55, settles at 0.0 → -0.55 * 50 = -27.5.
+        l.record_close(trade("Basis", "NO", "0.55", "0.0", "50", CloseKind::Settlement));
+        assert_eq!(l.realized(), dec!(60) - dec!(27.5));
+    }
+
+    #[test]
+    fn per_strategy_rollup_counts_wins() {
+        let mut l = Ledger::new(dec!(500));
+        l.record_close(trade("Momentum", "YES", "0.40", "0.50", "10", CloseKind::Exit)); // +1
+        l.record_close(trade("Momentum", "YES", "0.60", "0.50", "10", CloseKind::Exit)); // -1
+        let stats = l.per_strategy();
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].trades, 2);
+        assert_eq!(stats[0].wins, 1);
+        assert!((stats[0].win_rate - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn equity_curve_tracks_starting_plus_realized() {
+        let mut l = Ledger::new(dec!(500));
+        l.record_close(trade("Momentum", "YES", "0.40", "0.50", "100", CloseKind::Exit)); // +10
+        let ts = Utc::now();
+        l.push_equity(ts, dec!(5)); // +5 unrealized
+        assert_eq!(l.equity_curve().last().unwrap().1, dec!(515)); // 500 + 10 + 5
+    }
+}

--- a/src/backtest/llm_score.rs
+++ b/src/backtest/llm_score.rs
@@ -1,0 +1,204 @@
+//! W7 — Experimental LLM decision-scoring (off by default; `--llm-score`).
+//!
+//! At each Entry signal the decision context (viper, direction, key snapshot gate
+//! values, intended size/price) is serialized into a compact prompt and sent to the
+//! existing multi-provider LLM client (`helpers::llm_client::build_client`) for a
+//! 0–100 conviction score + one-line rationale. Responses are cached in the backtest
+//! SQLite keyed by a SHA-1 content hash, so reruns cost nothing and are reproducible.
+//! Scores are later joined with realized per-trade PnL in `report.json`.
+//!
+//! Provider/model/keys come from the SAME env/config the live advisor uses
+//! (`LlmSettings::resolve_from_env`). API keys are NEVER logged. Requests are issued
+//! sequentially (one awaited call per Entry).
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::Serialize;
+use sha1::{Digest, Sha1};
+use sqlx::{Row, SqlitePool};
+use tracing::{debug, warn};
+
+use crate::helpers::llm_client::{build_client, LlmChat, LlmSettings};
+use crate::state::{MarketSnapshot, OrderParams};
+
+/// One scored entry decision, joined to its realized outcome after the run.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScoredEntry {
+    pub strategy: String,
+    /// "YES" or "NO".
+    pub side: String,
+    pub entry_ts: DateTime<Utc>,
+    /// 0–100 conviction.
+    pub score: i32,
+    pub rationale: String,
+    /// Realized PnL of the matched trade (filled in after the run).
+    pub realized_pnl: Option<Decimal>,
+}
+
+pub struct LlmScorer {
+    client: Box<dyn LlmChat>,
+    pool: SqlitePool,
+    model_tag: String,
+}
+
+const SYSTEM: &str = "You are a quantitative trading decision scorer for a binary \
+prediction market (Polymarket YES/NO shares on hourly crypto up/down markets). Given \
+one entry decision's context, judge how convinced you are it is a good entry. Respond \
+EXACTLY in two lines and nothing else:\nSCORE: <integer 0-100>\nRATIONALE: <one short line>";
+
+impl LlmScorer {
+    /// Build the scorer from the live advisor's env/config and ensure the cache table
+    /// exists in the shared backtest DB. Returns `Err` (caller degrades to no scoring)
+    /// if no provider is configured.
+    pub async fn new(pool: SqlitePool) -> Result<Self> {
+        let settings = LlmSettings::resolve_from_env()?;
+        let client = build_client(&settings)?;
+        let model_tag = client.model_tag();
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS llm_scores (
+                hash TEXT PRIMARY KEY,
+                score INTEGER NOT NULL,
+                rationale TEXT NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await?;
+        Ok(Self { client, pool, model_tag })
+    }
+
+    /// Score one entry decision, using the cache when available.
+    pub async fn score_entry(
+        &mut self,
+        strategy: &str,
+        is_yes: bool,
+        wall_now: DateTime<Utc>,
+        snap: &MarketSnapshot,
+        params: &OrderParams,
+    ) -> Option<ScoredEntry> {
+        let side = if is_yes { "YES" } else { "NO" };
+        let user = format!(
+            "{{\"model\":\"{}\",\"viper\":\"{}\",\"direction\":\"{}\",\"oracle\":{},\
+\"velocity\":{},\"velocity_1s\":{},\"accel\":{},\"drift_10m\":{},\"drift_60m\":{},\
+\"funding\":{},\"secs_to_expiry\":{},\"yes_ask\":{},\"no_ask\":{},\"size_shares\":{},\
+\"price\":{}}}",
+            self.model_tag,
+            strategy,
+            side,
+            snap.oracle_price,
+            snap.velocity,
+            snap.velocity_1s,
+            snap.acceleration,
+            snap.oracle_drift_10m,
+            snap.oracle_drift_60m,
+            snap.funding_rate,
+            snap.secs_to_expiry,
+            snap.yes_ask,
+            snap.no_ask,
+            params.shares.round_dp(2),
+            params.price,
+        );
+
+        let hash = sha1_hex(&format!("{SYSTEM}\n{user}"));
+
+        // Cache hit?
+        if let Ok(Some(row)) = sqlx::query("SELECT score, rationale FROM llm_scores WHERE hash=?")
+            .bind(&hash)
+            .fetch_optional(&self.pool)
+            .await
+        {
+            let score: i64 = row.get("score");
+            let rationale: String = row.get("rationale");
+            debug!("🤖 LLM score cache hit ({strategy} {side}): {score}");
+            return Some(ScoredEntry {
+                strategy: strategy.to_string(),
+                side: side.to_string(),
+                entry_ts: wall_now,
+                score: score as i32,
+                rationale,
+                realized_pnl: None,
+            });
+        }
+
+        // Live call (sequential; API key never logged).
+        let (score, rationale) = match self.client.chat(SYSTEM, &user).await {
+            Ok(text) => parse_score(&text),
+            Err(e) => {
+                warn!("🤖 LLM scoring call failed ({strategy} {side}): {e}");
+                return None;
+            }
+        };
+
+        let _ = sqlx::query("INSERT OR REPLACE INTO llm_scores (hash, score, rationale) VALUES (?,?,?)")
+            .bind(&hash)
+            .bind(score as i64)
+            .bind(&rationale)
+            .execute(&self.pool)
+            .await;
+
+        Some(ScoredEntry {
+            strategy: strategy.to_string(),
+            side: side.to_string(),
+            entry_ts: wall_now,
+            score,
+            rationale,
+            realized_pnl: None,
+        })
+    }
+}
+
+fn sha1_hex(s: &str) -> String {
+    let mut h = Sha1::new();
+    h.update(s.as_bytes());
+    h.finalize().iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Parse "SCORE: <n>\nRATIONALE: <line>" leniently. Score clamped to [0, 100].
+fn parse_score(text: &str) -> (i32, String) {
+    let mut score = 50;
+    let mut rationale = String::new();
+    for line in text.lines() {
+        let l = line.trim();
+        if let Some(rest) = l.strip_prefix("SCORE:").or_else(|| l.strip_prefix("Score:")) {
+            // First whitespace-delimited token, allowing a leading sign.
+            if let Some(tok) = rest.split_whitespace().next() {
+                if let Ok(n) = tok.trim_matches(|c: char| !c.is_ascii_digit() && c != '-').parse::<i32>() {
+                    score = n.clamp(0, 100);
+                }
+            }
+        } else if let Some(rest) = l.strip_prefix("RATIONALE:").or_else(|| l.strip_prefix("Rationale:")) {
+            rationale = rest.trim().to_string();
+        }
+    }
+    if rationale.is_empty() {
+        rationale = text.trim().lines().next().unwrap_or("").to_string();
+    }
+    (score, rationale)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha1_is_stable() {
+        assert_eq!(sha1_hex("abc"), "a9993e364706816aba3e25717850c26c9cd0d89d");
+    }
+
+    #[test]
+    fn parses_well_formed_response() {
+        let (s, r) = parse_score("SCORE: 73\nRATIONALE: strong upward drift confirmed");
+        assert_eq!(s, 73);
+        assert_eq!(r, "strong upward drift confirmed");
+    }
+
+    #[test]
+    fn clamps_and_defaults() {
+        assert_eq!(parse_score("SCORE: 250\nRATIONALE: x").0, 100);
+        assert_eq!(parse_score("SCORE: -5\nRATIONALE: x").0, 0);
+        // Missing score defaults to 50; rationale falls back to first line.
+        let (s, r) = parse_score("no structured output here");
+        assert_eq!(s, 50);
+        assert_eq!(r, "no structured output here");
+    }
+}

--- a/src/backtest/mod.rs
+++ b/src/backtest/mod.rs
@@ -3,10 +3,12 @@
 //! # What this is
 //!
 //! A feature-gated (`--features backtest`) offline harness that replays historical
-//! Hyperliquid 1-minute candles + funding through the SAME `Strategy` trait objects
-//! the live bot runs (`StrategyRegistry::create_all_strategies()`), behind the W1
-//! clock seam (`ctx.wall_now` / `ctx.mono_now`) so every warmup / staleness /
-//! cooldown / hold-time gate evaluates against HISTORICAL time at any replay speed.
+//! 1-minute candles + funding through the SAME `Strategy` trait objects the live bot
+//! runs (`StrategyRegistry::create_all_strategies()`), behind the W1 clock seam
+//! (`ctx.wall_now` / `ctx.mono_now`) so every warmup / staleness / cooldown /
+//! hold-time gate evaluates against HISTORICAL time at any replay speed. Historical
+//! data comes from a selectable provider (`--source`): Hyperliquid (default) or
+//! Binance FAPI — see [`source`].
 //!
 //! Two PnL views are produced, deliberately labelled:
 //!   1. **Native Decimal ledger** (authoritative) — prices the actual binary YES/NO
@@ -35,7 +37,8 @@
 //!
 //! `hyperliquid-backtest` is deliberately NOT a dependency: its advertised
 //! fetch/backtest/report API is unreachable dead code in the published crate.
-//! Funding/candles are fetched directly from `https://api.hyperliquid.xyz/info`.
+//! Funding/candles are fetched directly from the API of the selected data source
+//! (Hyperliquid public info API or Binance FAPI, via `--source`).
 
 pub mod fetch;
 pub mod clock;
@@ -46,11 +49,13 @@ pub mod bridge;
 pub mod report;
 pub mod llm_score;
 pub mod entry;
+pub mod source;
 
 pub use clock::ReplayClock;
 pub use fetch::{BacktestCache, Candle, FundingPoint};
 pub use harness::{BacktestConfig, run_backtest};
-pub use synth::{book_model, normalize_funding_8h, BookQuote, SnapshotSynthesizer};
+pub use source::{build_source, HistoricalSource, SourceKind};
+pub use synth::{book_model, normalize_funding, normalize_funding_8h, BookQuote, SnapshotSynthesizer};
 
 /// Fidelity-tier disclaimer block, printed verbatim by the CLI and mirrored in the
 /// README. Kept in one place so the two never drift.

--- a/src/backtest/mod.rs
+++ b/src/backtest/mod.rs
@@ -1,0 +1,72 @@
+//! Backtesting subsystem — historical replay of REAL viper strategies.
+//!
+//! # What this is
+//!
+//! A feature-gated (`--features backtest`) offline harness that replays historical
+//! Hyperliquid 1-minute candles + funding through the SAME `Strategy` trait objects
+//! the live bot runs (`StrategyRegistry::create_all_strategies()`), behind the W1
+//! clock seam (`ctx.wall_now` / `ctx.mono_now`) so every warmup / staleness /
+//! cooldown / hold-time gate evaluates against HISTORICAL time at any replay speed.
+//!
+//! Two PnL views are produced, deliberately labelled:
+//!   1. **Native Decimal ledger** (authoritative) — prices the actual binary YES/NO
+//!      shares, settles 0/1 at expiry vs strike. See [`ledger`].
+//!   2. **rs-backtester metrics** (directional proxy) — Sharpe / drawdown / win-rate
+//!      on a `BUY/SHORTSELL/NULL` directional mapping of the underlying candle series.
+//!      `Order{BUY,SHORTSELL,NULL}` models a linear instrument, not a binary option.
+//!      See [`bridge`] + [`report`].
+//!
+//! # Honest fidelity tiers (published with every result)
+//!
+//! * **Tier A (high):** drift-gated directional logic — `drift_10m` / `drift_60m`
+//!   (60/10 one-minute samples — faithful) and strike-distance gates (e.g.
+//!   TrendReversal's drift/exhaustion entries).
+//! * **Tier B (medium):** velocity gates — `velocity_5s`/`velocity_1s` are derived
+//!   from 1-minute closes at 60s synthetic steps, so the sub-5s windows are
+//!   IDENTICALLY 0 (HL has no sub-5s candles). MOMENTUM is therefore effectively
+//!   EXCLUDED at 1m: every one of its entry branches requires `velocity ≠ 0`, so it
+//!   can never fire — its "0 trades" is a harness limitation, not a strategy verdict.
+//!   Funding is a real historical series.
+//! * **Tier C (model-dependent):** the 8 Polymarket book fields are a parametric
+//!   binary-option model (configurable spread/depth), and `institutional_pulse`,
+//!   `tide_coherence`, `oi_delta_pct`, `cvd_ratio` have no historical source and are
+//!   0. Convergence therefore no-ops by design (pulse=0 → NoSignal), and
+//!   TrendReversal's SQLite cascade guard no-ops without a live pool.
+//!
+//! `hyperliquid-backtest` is deliberately NOT a dependency: its advertised
+//! fetch/backtest/report API is unreachable dead code in the published crate.
+//! Funding/candles are fetched directly from `https://api.hyperliquid.xyz/info`.
+
+pub mod fetch;
+pub mod clock;
+pub mod synth;
+pub mod ledger;
+pub mod harness;
+pub mod bridge;
+pub mod report;
+pub mod llm_score;
+pub mod entry;
+
+pub use clock::ReplayClock;
+pub use fetch::{BacktestCache, Candle, FundingPoint};
+pub use harness::{BacktestConfig, run_backtest};
+pub use synth::{book_model, normalize_funding_8h, BookQuote, SnapshotSynthesizer};
+
+/// Fidelity-tier disclaimer block, printed verbatim by the CLI and mirrored in the
+/// README. Kept in one place so the two never drift.
+pub const FIDELITY_DISCLAIMER: &str = "\
+── Fidelity tiers (read before trusting these numbers) ─────────────────────────
+ Tier A (high)    drift_10m/drift_60m gates, strike-distance gates — faithful.
+ Tier B (medium)  velocity gates: velocity_5s/1s come from 1m closes at 60s steps,
+                  so sub-5s windows are IDENTICALLY 0 (HL has no sub-5s candles).
+                  MOMENTUM is therefore EXCLUDED at 1m — every entry branch needs
+                  velocity != 0, so it can never fire (its 0 trades is a harness
+                  limitation, not a verdict). Funding is a real historical series.
+ Tier C (model)   The 8 Polymarket book fields are a parametric binary-option model
+                  (configurable --spread/--depth), NOT a real order book. OI/CVD and
+                  institutional_pulse/tide_coherence have no historical source (=0),
+                  so CONVERGENCE is EXCLUDED (always no-ops), and TrendReversal's
+                  SQLite cascade guard no-ops. Funding is signal-only (binary shares
+                  pay no carry). The rs-backtester Sharpe/drawdown/win-rate are a
+                  DIRECTIONAL PROXY on the underlying, not the binary payoff.
+────────────────────────────────────────────────────────────────────────────────";

--- a/src/backtest/report.rs
+++ b/src/backtest/report.rs
@@ -224,6 +224,7 @@ pub fn build_report_json(
 
     serde_json::json!({
         "coin": cfg.coin,
+        "source": cfg.source.as_str(),
         "interval": cfg.interval,
         "start_ms": cfg.start_ms,
         "end_ms": cfg.end_ms,
@@ -260,8 +261,8 @@ pub fn build_report_json(
 pub fn print_summary(cfg: &BacktestConfig, outcome: &BacktestOutcome, rs: &Option<RsMetrics>) {
     println!("\n════════════════════ DRADIS BACKTEST ════════════════════");
     println!(
-        " {} {}  |  {} ticks over {} synthetic hourly markets",
-        cfg.coin, cfg.interval, outcome.ticks, outcome.markets
+        " {} {}  [{}]  |  {} ticks over {} synthetic hourly markets",
+        cfg.coin, cfg.interval, cfg.source.as_str(), outcome.ticks, outcome.markets
     );
     println!(
         " spread=±{}  depth={}sh/side  commission={}",

--- a/src/backtest/report.rs
+++ b/src/backtest/report.rs
@@ -1,0 +1,332 @@
+//! W6 — Reporting: rs-backtester metrics (directional proxy) + native Decimal output.
+//!
+//! Emits two deliberately-labelled PnL views:
+//!   1. the **native Decimal ledger** (authoritative binary settlement), and
+//!   2. **rs-backtester** Sharpe/drawdown/win-rate on the directional proxy.
+//!
+//! rs-backtester's commission is a PROCESS-GLOBAL singleton: `update_config` is called
+//! immediately before `Backtest::new`, single-threaded, so no concurrent construction
+//! can race the global `RwLock`. `plot()`/`i_chart()` are NEVER called (they hard-code
+//! a Windows `"\\"` path join that corrupts output on Linux) — we only read
+//! `Backtest.metrics` and print `report_horizontal`.
+
+use std::fs;
+use std::io::Write;
+use std::panic::AssertUnwindSafe;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::DateTime;
+use rust_decimal::Decimal;
+
+use rs_backtester::backtester::Backtest;
+use rs_backtester::config::update_config;
+use rs_backtester::data::Data;
+use rs_backtester::metrics::report_horizontal;
+use rs_backtester::strategies::Strategy as RsStrategy;
+
+use super::bridge::{dec_to_f64, dec_to_u64, to_orders, Stance};
+use super::fetch::Candle;
+use super::harness::{BacktestConfig, BacktestOutcome};
+use super::FIDELITY_DISCLAIMER;
+
+/// Extracted rs-backtester metrics (kept as a plain struct so rs types don't leak).
+#[derive(Debug, Clone, Default)]
+pub struct RsMetrics {
+    pub bt_return_pct: Option<f64>,
+    pub sharpe: Option<f64>,
+    pub max_drawdown_pct: Option<f64>,
+    pub win_rate_pct: Option<f64>,
+    pub trades_nr: Option<usize>,
+}
+
+/// Build an rs-backtester `Data` from the candle series (the single f64/u64 boundary).
+fn build_data(coin: &str, candles: &[Candle]) -> Data {
+    let mut datetime = Vec::with_capacity(candles.len());
+    let mut open = Vec::with_capacity(candles.len());
+    let mut high = Vec::with_capacity(candles.len());
+    let mut low = Vec::with_capacity(candles.len());
+    let mut close = Vec::with_capacity(candles.len());
+    let mut volume = Vec::with_capacity(candles.len());
+    for c in candles {
+        let dt = DateTime::from_timestamp_millis(c.ts_ms)
+            .unwrap_or_else(|| DateTime::from_timestamp(0, 0).unwrap())
+            .fixed_offset();
+        datetime.push(dt);
+        open.push(dec_to_f64(c.open));
+        high.push(dec_to_f64(c.high));
+        low.push(dec_to_f64(c.low));
+        close.push(dec_to_f64(c.close));
+        volume.push(dec_to_u64(c.volume));
+    }
+    Data { ticker: coin.to_string(), datetime, open, high, low, close, volume }
+}
+
+/// Run the rs-backtester directional proxy and return its metrics. Returns `None`
+/// (and logs) if the series is too short or the crate panics on the data.
+pub fn run_rs_backtester(
+    coin: &str,
+    candles: &[Candle],
+    stances: &[Stance],
+    commission: Decimal,
+    initial: f64,
+) -> Option<RsMetrics> {
+    if candles.len() < 2 || candles.len() != stances.len() {
+        tracing::warn!(
+            "rs-backtester skipped: need ≥2 aligned candles/stances (got {} / {})",
+            candles.len(),
+            stances.len()
+        );
+        return None;
+    }
+
+    // Global config singleton — set BEFORE Backtest::new, single-threaded.
+    // Also swap the default `AllInSizerWholeUnits` (which sizes in WHOLE units of the
+    // underlying and so truncates to 0 for any coin priced above the starting
+    // collateral — BTC/ETH — yielding a constant networth, 0% return and NaN sharpe)
+    // for the FRACTIONAL `AllInSizer`, so the directional proxy actually trades.
+    let rate = dec_to_f64(commission);
+    update_config(move |cfg| {
+        cfg.commission_rate = rate;
+        cfg.sizer = Box::new(rs_backtester::risk_manager::AllInSizer);
+    });
+
+    let data = Arc::new(build_data(coin, candles));
+    let strategy = RsStrategy {
+        name: format!("{coin} directional proxy"),
+        choices: to_orders(stances),
+        indicator: None,
+        data,
+    };
+
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let bt = Backtest::new(strategy, initial);
+        report_horizontal(&[&bt]);
+        let m = &bt.metrics;
+        RsMetrics {
+            bt_return_pct: m.bt_return,
+            sharpe: m.sharpe,
+            max_drawdown_pct: m.max_drawd.map(|d| d * 100.0),
+            win_rate_pct: m.win_rate.map(|w| w * 100.0),
+            trades_nr: m.trades_nr,
+        }
+    }));
+
+    match result {
+        Ok(m) => Some(m),
+        Err(_) => {
+            tracing::warn!("rs-backtester panicked on this series — skipping proxy metrics");
+            None
+        }
+    }
+}
+
+fn final_equity(outcome: &BacktestOutcome) -> Decimal {
+    outcome
+        .ledger
+        .equity_curve()
+        .last()
+        .map(|(_, e)| *e)
+        .unwrap_or_else(|| outcome.ledger.starting() + outcome.ledger.realized())
+}
+
+/// Write `report.json`, `trades.csv`, and `equity.csv` into `cfg.out_dir`.
+pub fn write_native(cfg: &BacktestConfig, outcome: &BacktestOutcome, rs: &Option<RsMetrics>) -> Result<()> {
+    let dir = Path::new(&cfg.out_dir);
+    fs::create_dir_all(dir).with_context(|| format!("creating out dir {}", cfg.out_dir))?;
+
+    // ── trades.csv ──────────────────────────────────────────────────────────
+    let mut tf = fs::File::create(dir.join("trades.csv")).context("creating trades.csv")?;
+    writeln!(tf, "strategy,side,kind,entry_ts,exit_ts,entry_price,exit_price,shares,pnl,reason")?;
+    for t in outcome.ledger.closed_trades() {
+        writeln!(
+            tf,
+            "{},{},{:?},{},{},{},{},{},{},{}",
+            t.strategy,
+            t.side,
+            t.kind,
+            t.entry_ts.to_rfc3339(),
+            t.exit_ts.to_rfc3339(),
+            t.entry_price,
+            t.exit_price,
+            t.shares,
+            t.pnl,
+            csv_escape(&t.reason),
+        )?;
+    }
+
+    // ── equity.csv ──────────────────────────────────────────────────────────
+    let mut ef = fs::File::create(dir.join("equity.csv")).context("creating equity.csv")?;
+    writeln!(ef, "ts,equity")?;
+    for (ts, eq) in outcome.ledger.equity_curve() {
+        writeln!(ef, "{},{}", ts.to_rfc3339(), eq)?;
+    }
+
+    // ── report.json ─────────────────────────────────────────────────────────
+    let report = build_report_json(cfg, outcome, rs);
+
+    let mut rf = fs::File::create(dir.join("report.json")).context("creating report.json")?;
+    rf.write_all(serde_json::to_string_pretty(&report)?.as_bytes())?;
+
+    tracing::info!("📝 wrote report.json / trades.csv / equity.csv to {}", cfg.out_dir);
+    Ok(())
+}
+
+/// Build the `report.json` document as a `serde_json::Value`. This is the single
+/// source of truth for the report structure — `write_native` serializes it to disk
+/// for the CLI, and the feature-gated Control Tower backtest API serves it verbatim.
+pub fn build_report_json(
+    cfg: &BacktestConfig,
+    outcome: &BacktestOutcome,
+    rs: &Option<RsMetrics>,
+) -> serde_json::Value {
+    let per_strategy: Vec<serde_json::Value> = outcome
+        .ledger
+        .per_strategy()
+        .into_iter()
+        .map(|s| {
+            serde_json::json!({
+                "strategy": s.strategy,
+                "trades": s.trades,
+                "wins": s.wins,
+                "win_rate_pct": (s.win_rate * 100.0),
+                "pnl": s.pnl.to_string(),
+            })
+        })
+        .collect();
+
+    let rs_json = rs.as_ref().map(|m| {
+        serde_json::json!({
+            "note": "directional proxy on the underlying (BUY/SHORTSELL/NULL), NOT the binary payoff",
+            "return_pct": m.bt_return_pct,
+            "sharpe": m.sharpe,
+            "max_drawdown_pct": m.max_drawdown_pct,
+            "win_rate_pct": m.win_rate_pct,
+            "trades_nr": m.trades_nr,
+        })
+    });
+
+    let llm_json: Vec<serde_json::Value> = outcome
+        .scored_entries
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "strategy": s.strategy,
+                "side": s.side,
+                "entry_ts": s.entry_ts.to_rfc3339(),
+                "score": s.score,
+                "rationale": s.rationale,
+                "realized_pnl": s.realized_pnl.map(|p| p.to_string()),
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "coin": cfg.coin,
+        "interval": cfg.interval,
+        "start_ms": cfg.start_ms,
+        "end_ms": cfg.end_ms,
+        // Requested start/end above are the CLI window; these are the range actually
+        // replayed. They differ when Hyperliquid's ~5000-candle tail retention
+        // head-truncates the request (a warning is also logged at run time).
+        "replayed_start_ms": outcome.candles.first().map(|c| c.ts_ms),
+        "replayed_end_ms": outcome.candles.last().map(|c| c.ts_ms),
+        "ticks": outcome.ticks,
+        "markets": outcome.markets,
+        "params": {
+            "spread": cfg.half_spread.to_string(),
+            "depth": cfg.depth.to_string(),
+            "commission": cfg.commission.to_string(),
+            "strategies": cfg.strategies,
+            "llm_score": cfg.llm_score,
+        },
+        "native_ledger": {
+            "note": "AUTHORITATIVE — prices real binary YES/NO shares, settles 0/1 at expiry",
+            "starting_collateral": outcome.ledger.starting().to_string(),
+            "realized_pnl": outcome.ledger.realized().to_string(),
+            "final_equity": final_equity(outcome).to_string(),
+            "closed_trades": outcome.ledger.closed_trades().len(),
+            "per_strategy": per_strategy,
+        },
+        "rs_backtester": rs_json,
+        "llm_scores": llm_json,
+        "fidelity": FIDELITY_DISCLAIMER,
+    })
+}
+
+/// Human-readable stdout summary: per-strategy table, native PnL, proxy metrics, and
+/// the fidelity-tier disclaimer block.
+pub fn print_summary(cfg: &BacktestConfig, outcome: &BacktestOutcome, rs: &Option<RsMetrics>) {
+    println!("\n════════════════════ DRADIS BACKTEST ════════════════════");
+    println!(
+        " {} {}  |  {} ticks over {} synthetic hourly markets",
+        cfg.coin, cfg.interval, outcome.ticks, outcome.markets
+    );
+    println!(
+        " spread=±{}  depth={}sh/side  commission={}",
+        cfg.half_spread, cfg.depth, cfg.commission
+    );
+    println!("──────────────────────────────────────────────────────────");
+    println!(
+        " {:<16} {:>7} {:>7} {:>10}",
+        "Strategy", "Trades", "Win%", "PnL($)"
+    );
+    let per = outcome.ledger.per_strategy();
+    if per.is_empty() {
+        println!("   (no trades fired — all vipers stood down over this window)");
+    }
+    for s in &per {
+        println!(
+            " {:<16} {:>7} {:>6.1}% {:>10}",
+            s.strategy,
+            s.trades,
+            s.win_rate * 100.0,
+            round2(s.pnl)
+        );
+    }
+    println!("──────────────────────────────────────────────────────────");
+    println!(" NATIVE LEDGER (authoritative binary settlement)");
+    println!("   starting     : ${}", cfg.starting_collateral);
+    println!("   realized PnL : ${}", round2(outcome.ledger.realized()));
+    println!("   final equity : ${}", round2(final_equity(outcome)));
+    println!("   closed trades: {}", outcome.ledger.closed_trades().len());
+    match rs {
+        Some(m) => {
+            println!(" RS-BACKTESTER (directional proxy on the underlying)");
+            println!(
+                "   return={}  sharpe={}  maxDD={}  winRate={}  trades={}",
+                fmt_opt_pct(m.bt_return_pct),
+                fmt_opt(m.sharpe),
+                fmt_opt_pct(m.max_drawdown_pct),
+                fmt_opt_pct(m.win_rate_pct),
+                m.trades_nr.map(|n| n.to_string()).unwrap_or_else(|| "-".into()),
+            );
+        }
+        None => println!(" RS-BACKTESTER : (skipped — see log)"),
+    }
+    if !outcome.scored_entries.is_empty() {
+        let n = outcome.scored_entries.len();
+        let avg = outcome.scored_entries.iter().map(|s| s.score as f64).sum::<f64>() / n as f64;
+        println!(" LLM SCORING  : {n} entries scored (avg conviction {avg:.0}/100) — see report.json");
+    }
+    println!("{FIDELITY_DISCLAIMER}");
+    println!("══════════════════════════════════════════════════════════\n");
+}
+
+fn round2(d: Decimal) -> Decimal {
+    d.round_dp(2)
+}
+fn fmt_opt(v: Option<f64>) -> String {
+    v.map(|x| format!("{x:.2}")).unwrap_or_else(|| "-".into())
+}
+fn fmt_opt_pct(v: Option<f64>) -> String {
+    v.map(|x| format!("{x:.2}%")).unwrap_or_else(|| "-".into())
+}
+fn csv_escape(s: &str) -> String {
+    if s.contains([',', '"', '\n']) {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}

--- a/src/backtest/source/binance.rs
+++ b/src/backtest/source/binance.rs
@@ -1,0 +1,322 @@
+//! Binance FAPI historical-market-data provider.
+//!
+//! Reads candles and funding history from Binance USDⓈ-M **futures** (FAPI,
+//! `fapi.binance.com`), never spot: funding only exists on futures, pulling both
+//! series from the same instrument keeps them time-aligned, and perp prices embed
+//! the basis a perp strategy actually experiences. FAPI is already this codebase's
+//! canonical Binance host (`raptors/funding.rs`, `raptors/derivatives.rs`).
+//!
+//! Plain `reqwest` GETs, no SDK — same shape as the Hyperliquid provider. Each
+//! endpoint owns its own pagination loop (Binance's page caps and cursor rules
+//! differ from Hyperliquid's, hence no shared driver):
+//!   * `GET /fapi/v1/klines` — `limit=1500` (the empirically verified ceiling; the
+//!     SDK docstring's "max 1000" is stale — 1501 rows returns HTTP 400 `-1130`).
+//!     Each row is a 12-element array; OHLCV (indices 1-5) are JSON STRINGS,
+//!     parsed via `fetch::dec`, never `as_f64`.
+//!   * `GET /fapi/v1/fundingRate` — `limit=1000`, with an ALWAYS-explicit
+//!     `startTime`: verified live, omitting it silently caps the response at
+//!     ~500 rows regardless of `limit`. Rates are cached in Binance's native
+//!     per-8h cadence; normalization is `synth::normalize_funding`'s job.
+//!
+//! No retry logic in v1 (matches the Hyperliquid provider); the 200ms inter-page
+//! delay keeps us far from 429/418 alongside the live funding/derivatives raptors
+//! already polling this same host from this IP.
+
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+use tracing::info;
+
+use super::{FundingPoint, HistoricalSource};
+use crate::backtest::fetch::{dec, interval_ms, Candle};
+
+const KLINES_URL: &str = "https://fapi.binance.com/fapi/v1/klines";
+const FUNDING_URL: &str = "https://fapi.binance.com/fapi/v1/fundingRate";
+const PAGE_DELAY: Duration = Duration::from_millis(200);
+
+pub struct BinanceSource {
+    http: reqwest::Client,
+}
+
+impl BinanceSource {
+    /// FAPI market-data endpoints are public and IP-rate-limited — an API key
+    /// changes nothing for them (verified live), so this provider takes no
+    /// credentials of any kind.
+    pub fn new() -> Self {
+        Self { http: reqwest::Client::new() }
+    }
+}
+
+impl Default for BinanceSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BinanceSource {
+    /// Shared GET-and-decode path for both endpoints — critically, it checks
+    /// the HTTP status BEFORE attempting a JSON decode. Binance's error
+    /// envelope is NOT uniform: most endpoints return `{"code":-1121,"msg":"..."}`,
+    /// but `fundingRate` was observed live returning a WAF-style
+    /// `{status,type,code,errorData}` shape on failure — so we never assume a
+    /// `{code,msg}` shape, just surface the raw (truncated) body.
+    async fn get_json(&self, url: &str, query: &[(&str, String)]) -> Result<Value> {
+        let resp = self
+            .http
+            .get(url)
+            .query(query)
+            .send()
+            .await
+            .with_context(|| format!("binance request failed: {url}"))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let truncated: String = body.chars().take(300).collect();
+            bail!("binance {status}: {truncated}");
+        }
+        resp.json::<Value>()
+            .await
+            .with_context(|| format!("binance response decode failed: {url}"))
+    }
+}
+
+#[async_trait]
+impl HistoricalSource for BinanceSource {
+    fn id(&self) -> &'static str {
+        "binance"
+    }
+
+    /// Map a DRADIS coin (e.g. "BTC") onto Binance FAPI's wire symbol:
+    /// `{COIN}USDT`. Correct for BTC/ETH/SOL — verified live.
+    ///
+    /// **Known limitation:** Binance FUTURES rebases low-price meme coins into
+    /// the symbol itself (`1000PEPEUSDT`, even `1000000MOGUSDT`), while spot
+    /// lists them unprefixed and Hyperliquid uses `kPEPE` — three different
+    /// naming schemes for the same coin. If the tradable universe grows past
+    /// majors, this must become an explicit per-coin lookup table (cf.
+    /// `raptors/source.rs`'s per-venue symbol tables). Chosen failure mode:
+    /// naive concat + loud failure — an unmapped coin surfaces Binance's own
+    /// `{"code":-1121,"msg":"Invalid symbol."}` as a hard error; it can never
+    /// silently mis-map for the majors DRADIS actually trades.
+    fn resolve_symbol(&self, coin: &str) -> String {
+        format!("{}USDT", coin.to_uppercase())
+    }
+
+    /// Binance FAPI majors settle funding every 8h.
+    ///
+    /// **Known limitation:** this is hardcoded — Binance runs non-8h cadences
+    /// on some symbols (queryable via `/fapi/v1/fundingInfo`, weight 0). Safe
+    /// for BTC/ETH/SOL; revisit before expanding the universe.
+    fn funding_period_hours(&self) -> u32 {
+        8
+    }
+
+    async fn fetch_candles(
+        &self,
+        coin: &str,
+        interval: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<Vec<Candle>> {
+        let symbol = self.resolve_symbol(coin);
+        let step = interval_ms(interval)?;
+        let mut cursor = start_ms;
+        let mut out = Vec::new();
+
+        while cursor < end_ms {
+            let params = [
+                ("symbol", symbol.clone()),
+                ("interval", interval.to_string()),
+                ("startTime", cursor.to_string()),
+                ("endTime", end_ms.to_string()),
+                ("limit", "1500".to_string()),
+            ];
+            let json = self.get_json(KLINES_URL, &params).await?;
+            let arr = json.as_array().cloned().unwrap_or_default();
+            if arr.is_empty() {
+                break;
+            }
+            let page_len = arr.len();
+            // Binance returns klines ascending by open time, so the last row in the
+            // page carries the highest openTime regardless of whether it fell inside
+            // [start_ms, end_ms) — used for the cursor advance below, independent of
+            // which rows we actually keep.
+            let last_open_time = arr
+                .last()
+                .and_then(|row| row.as_array())
+                .and_then(|cells| cells.first())
+                .and_then(Value::as_i64)
+                .unwrap_or(cursor);
+
+            for row in &arr {
+                let Some(cells) = row.as_array() else {
+                    continue;
+                };
+                if cells.len() < 6 {
+                    continue;
+                }
+                let Some(ts_ms) = cells[0].as_i64() else {
+                    continue;
+                };
+                if ts_ms >= end_ms {
+                    continue;
+                }
+                let (Some(o), Some(h), Some(l), Some(c), Some(v)) = (
+                    cells[1].as_str(),
+                    cells[2].as_str(),
+                    cells[3].as_str(),
+                    cells[4].as_str(),
+                    cells[5].as_str(),
+                ) else {
+                    continue;
+                };
+                out.push(Candle {
+                    ts_ms,
+                    open: dec(o)?,
+                    high: dec(h)?,
+                    low: dec(l)?,
+                    close: dec(c)?,
+                    volume: dec(v)?,
+                });
+            }
+
+            // Advance past the last candle Binance returned; guarantee forward
+            // progress so a malformed/empty-ish page can never spin forever.
+            let next = last_open_time + step;
+            if next <= cursor {
+                break;
+            }
+            cursor = next;
+            if page_len < 1500 || cursor >= end_ms {
+                break; // short page (tail reached) or window exhausted
+            }
+            tokio::time::sleep(PAGE_DELAY).await;
+        }
+
+        info!("✅ binance candles fetched: {} rows [{symbol} {interval}]", out.len());
+        Ok(out)
+    }
+
+    async fn fetch_funding(
+        &self,
+        coin: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<Vec<FundingPoint>> {
+        let symbol = self.resolve_symbol(coin);
+        let mut cursor = start_ms;
+        let mut out = Vec::new();
+
+        while cursor < end_ms {
+            let params = [
+                ("symbol", symbol.clone()),
+                // ALWAYS explicit — verified live: omitting startTime silently caps
+                // the response at ~500 rows regardless of `limit`.
+                ("startTime", cursor.to_string()),
+                ("endTime", end_ms.to_string()),
+                ("limit", "1000".to_string()),
+            ];
+            let json = self.get_json(FUNDING_URL, &params).await?;
+            let arr = json.as_array().cloned().unwrap_or_default();
+            if arr.is_empty() {
+                break;
+            }
+            let page_len = arr.len();
+            let last_funding_time = arr
+                .last()
+                .and_then(|o| o.get("fundingTime"))
+                .and_then(Value::as_i64)
+                .unwrap_or(cursor);
+
+            for obj in &arr {
+                let Some(ts_ms) = obj.get("fundingTime").and_then(Value::as_i64) else {
+                    continue;
+                };
+                if ts_ms >= end_ms {
+                    continue;
+                }
+                // `markPrice` may be an empty string pre-2020 and is unused here.
+                let Some(rate) = obj.get("fundingRate").and_then(Value::as_str) else {
+                    continue;
+                };
+                out.push(FundingPoint { ts_ms, rate: dec(rate)? });
+            }
+
+            let next = last_funding_time + 1;
+            if next <= cursor {
+                break;
+            }
+            cursor = next;
+            if page_len < 1000 || cursor >= end_ms {
+                break;
+            }
+            tokio::time::sleep(PAGE_DELAY).await;
+        }
+
+        info!("✅ binance funding fetched: {} rows [{symbol}]", out.len());
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+
+    #[test]
+    fn resolve_symbol_appends_usdt() {
+        let src = BinanceSource::new();
+        assert_eq!(src.resolve_symbol("btc"), "BTCUSDT");
+        assert_eq!(src.resolve_symbol("BTC"), "BTCUSDT");
+        assert_eq!(src.resolve_symbol("eth"), "ETHUSDT");
+    }
+
+    #[test]
+    fn id_and_funding_period() {
+        let src = BinanceSource::new();
+        assert_eq!(src.id(), "binance");
+        assert_eq!(src.funding_period_hours(), 8);
+    }
+
+    /// One raw `/fapi/v1/klines` row: 12-element array, OHLCV as JSON strings.
+    #[test]
+    fn kline_row_ohlcv_strings_parse_as_decimal() {
+        let row: Value = serde_json::from_str(
+            r#"[1625097600000,"42055.50","42200.00","41950.10","42100.75","1234.567",
+               1625097659999,"51987654.32",1000,"600.111","25987654.32","0"]"#,
+        )
+        .unwrap();
+        let cells = row.as_array().unwrap();
+        assert_eq!(cells[0].as_i64().unwrap(), 1625097600000);
+        assert_eq!(dec(cells[1].as_str().unwrap()).unwrap(), Decimal::from_str("42055.50").unwrap());
+        assert_eq!(dec(cells[4].as_str().unwrap()).unwrap(), Decimal::from_str("42100.75").unwrap());
+    }
+
+    /// One raw `/fapi/v1/fundingRate` object; `markPrice` may be empty pre-2020
+    /// and is intentionally ignored.
+    #[test]
+    fn funding_object_rate_string_parses_as_decimal() {
+        let obj: Value = serde_json::from_str(
+            r#"{"symbol":"BTCUSDT","fundingTime":1625097600000,"fundingRate":"0.00010000","markPrice":""}"#,
+        )
+        .unwrap();
+        assert_eq!(obj.get("fundingTime").and_then(Value::as_i64).unwrap(), 1625097600000);
+        let rate = dec(obj.get("fundingRate").and_then(Value::as_str).unwrap()).unwrap();
+        assert_eq!(rate, Decimal::from_str("0.00010000").unwrap());
+    }
+
+    /// A non-`{code,msg}` (WAF-style) error body must not be assumed — the caller
+    /// only needs it to surface as an opaque error, not to parse a specific shape.
+    #[test]
+    fn non_standard_error_envelope_is_opaque_not_parsed() {
+        let body = r#"{"status":403,"type":"about:blank","code":0,"errorData":null}"#;
+        let parsed: Result<Value, _> = serde_json::from_str(body);
+        assert!(parsed.is_ok()); // valid JSON, just not the {code,msg} shape
+        let v = parsed.unwrap();
+        assert!(v.get("code").is_some()); // has "code" but as an int, not the -1xxx string envelope
+        assert!(v.get("msg").is_none()); // no "msg" field at all — {code,msg} assumption would fail here
+    }
+}

--- a/src/backtest/source/hyperliquid.rs
+++ b/src/backtest/source/hyperliquid.rs
@@ -1,0 +1,256 @@
+//! Hyperliquid historical-market-data provider — the DRADIS default `--source`.
+//!
+//! Wire code moved verbatim from the pre-refactor `fetch.rs::{fetch_candles_range,
+//! fetch_funding_range}`: plain `reqwest` POSTs against the public Hyperliquid Info
+//! API (`https://api.hyperliquid.xyz/info`) — the same wire shape
+//! `helpers::time.rs::fetch_hyperliquid_close` already uses, so no
+//! `hyperliquid_rust_sdk` and no `hyperliquid` cargo feature are required here (that
+//! feature stays reserved for the live SDK raptor).
+//!
+//!   * `candleSnapshot` — OHLCV. The endpoint caps each response at ~5000 candles
+//!     and anchors responses at the TAIL, retaining only the most recent ~5000
+//!     candles — a requested window older than that is head-truncated at the
+//!     source (unfetchable; the harness detects and warns about this). Every OHLCV
+//!     field is a JSON STRING, parsed via `fetch::dec`. Pagination advances
+//!     `startTime` past the last candle returned, with a forward-progress guard and
+//!     a short-page (< 4000 rows) tail stop.
+//!   * `fundingHistory` — hourly funding series, paginated the same way with a
+//!     `max_t + 1` cursor and a short-page (< 400 rows) tail stop.
+//!
+//! This provider owns ONLY the wire protocol: it returns plain
+//! `Vec<Candle>`/`Vec<FundingPoint>` and never touches SQLite. In particular, the
+//! "never persist a still-forming candle" rule that used to live in this file's
+//! pagination loop has moved to `BacktestCache::upsert_candles` — a
+//! caching-correctness rule, not a wire-protocol one — so `fetch_candles` MAY
+//! return the currently-forming final bar.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+use super::{FundingPoint, HistoricalSource};
+use crate::backtest::fetch::{dec, interval_ms, Candle};
+
+const INFO_URL: &str = "https://api.hyperliquid.xyz/info";
+const PAGE_DELAY: Duration = Duration::from_millis(200);
+
+pub struct HyperliquidSource {
+    http: reqwest::Client,
+}
+
+impl HyperliquidSource {
+    /// Hyperliquid's public `info` API is unauthenticated — it has no auth
+    /// field at all, so this provider takes no credentials of any kind.
+    pub fn new() -> Self {
+        Self { http: reqwest::Client::new() }
+    }
+}
+
+impl Default for HyperliquidSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl HistoricalSource for HyperliquidSource {
+    fn id(&self) -> &'static str {
+        "hyperliquid"
+    }
+
+    fn resolve_symbol(&self, coin: &str) -> String {
+        coin.to_uppercase()
+    }
+
+    fn funding_period_hours(&self) -> u32 {
+        1
+    }
+
+    /// Paginated `candleSnapshot` fetch. Ascending by open-time `ts_ms`. MAY
+    /// include the still-forming final bar — the cache strips it on insert.
+    async fn fetch_candles(
+        &self,
+        coin: &str,
+        interval: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<Vec<Candle>> {
+        let step = interval_ms(interval)?;
+        let mut cursor = start_ms;
+        let mut out = Vec::new();
+        while cursor < end_ms {
+            let body = serde_json::json!({
+                "type": "candleSnapshot",
+                "req": { "coin": coin, "interval": interval, "startTime": cursor, "endTime": end_ms }
+            });
+            let json: serde_json::Value = self
+                .http
+                .post(INFO_URL)
+                .json(&body)
+                .send()
+                .await
+                .context("candleSnapshot POST failed")?
+                .json()
+                .await
+                .context("candleSnapshot decode failed")?;
+            let arr = json.as_array().cloned().unwrap_or_default();
+            if arr.is_empty() {
+                break;
+            }
+            let mut max_t = cursor;
+            for c in &arr {
+                let (Some(t), Some(o), Some(h), Some(l), Some(cl), Some(v)) = (
+                    c.get("t").and_then(|x| x.as_i64()),
+                    c.get("o").and_then(|x| x.as_str()),
+                    c.get("h").and_then(|x| x.as_str()),
+                    c.get("l").and_then(|x| x.as_str()),
+                    c.get("c").and_then(|x| x.as_str()),
+                    c.get("v").and_then(|x| x.as_str()),
+                ) else {
+                    continue;
+                };
+                if t >= end_ms {
+                    continue;
+                }
+                max_t = max_t.max(t);
+                out.push(Candle {
+                    ts_ms: t,
+                    open: dec(o)?,
+                    high: dec(h)?,
+                    low: dec(l)?,
+                    close: dec(cl)?,
+                    volume: dec(v)?,
+                });
+            }
+
+            // Advance past the last candle we saw; guarantee forward progress.
+            let next = max_t + step;
+            if next <= cursor {
+                break;
+            }
+            cursor = next;
+            // Stop once a short page (< cap) tells us we reached the tail.
+            if arr.len() < 4000 {
+                break;
+            }
+            tokio::time::sleep(PAGE_DELAY).await;
+        }
+        Ok(out)
+    }
+
+    /// Paginated `fundingHistory` fetch. Ascending. Rates are the raw HOURLY HL
+    /// rate — normalization onto the canonical per-8h scale happens in
+    /// `synth::normalize_funding`, not here.
+    async fn fetch_funding(
+        &self,
+        coin: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<Vec<FundingPoint>> {
+        let mut cursor = start_ms;
+        let mut out = Vec::new();
+        while cursor < end_ms {
+            let body = serde_json::json!({
+                "type": "fundingHistory", "coin": coin, "startTime": cursor, "endTime": end_ms
+            });
+            let json: serde_json::Value = self
+                .http
+                .post(INFO_URL)
+                .json(&body)
+                .send()
+                .await
+                .context("fundingHistory POST failed")?
+                .json()
+                .await
+                .context("fundingHistory decode failed")?;
+            let arr = json.as_array().cloned().unwrap_or_default();
+            if arr.is_empty() {
+                break;
+            }
+            let mut max_t = cursor;
+            for f in &arr {
+                let (Some(t), Some(rate)) = (
+                    f.get("time").and_then(|x| x.as_i64()),
+                    f.get("fundingRate").and_then(|x| x.as_str()),
+                ) else {
+                    continue;
+                };
+                if t >= end_ms {
+                    continue;
+                }
+                max_t = max_t.max(t);
+                out.push(FundingPoint {
+                    ts_ms: t,
+                    rate: dec(rate)?,
+                });
+            }
+
+            // Advance past the last observation we saw; guarantee forward progress.
+            let next = max_t + 1;
+            if next <= cursor {
+                break;
+            }
+            cursor = next;
+            // Stop once a short page (< cap) tells us we reached the tail.
+            if arr.len() < 400 {
+                break;
+            }
+            tokio::time::sleep(PAGE_DELAY).await;
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal::Decimal;
+    use serde_json::Value;
+    use std::str::FromStr;
+
+    #[test]
+    fn resolve_symbol_is_identity_uppercased() {
+        let src = HyperliquidSource::new();
+        assert_eq!(src.resolve_symbol("btc"), "BTC");
+        assert_eq!(src.resolve_symbol("BTC"), "BTC");
+        assert_eq!(src.resolve_symbol("Eth"), "ETH");
+    }
+
+    #[test]
+    fn id_and_funding_period() {
+        let src = HyperliquidSource::new();
+        assert_eq!(src.id(), "hyperliquid");
+        assert_eq!(src.funding_period_hours(), 1);
+    }
+
+    /// One raw `candleSnapshot` row: `t` is a JSON number, `o/h/l/c/v` are JSON
+    /// STRINGS parsed via `fetch::dec`, never `as_f64`.
+    #[test]
+    fn candle_snapshot_row_ohlcv_strings_parse_as_decimal() {
+        let row: Value = serde_json::from_str(
+            r#"{"t":1625097600000,"o":"42055.50","h":"42200.00","l":"41950.10",
+               "c":"42100.75","v":"1234.567","T":1625097659999,"s":"BTC","i":"1m"}"#,
+        )
+        .unwrap();
+        assert_eq!(row.get("t").and_then(Value::as_i64).unwrap(), 1625097600000);
+        let o = dec(row.get("o").and_then(Value::as_str).unwrap()).unwrap();
+        assert_eq!(o, Decimal::from_str("42055.50").unwrap());
+        let c = dec(row.get("c").and_then(Value::as_str).unwrap()).unwrap();
+        assert_eq!(c, Decimal::from_str("42100.75").unwrap());
+    }
+
+    /// One raw `fundingHistory` object: `time` is a JSON number, `fundingRate` is a
+    /// JSON string parsed via `fetch::dec`; native hourly cadence, normalized only
+    /// in `synth::normalize_funding`.
+    #[test]
+    fn funding_history_object_rate_string_parses_as_decimal() {
+        let obj: Value = serde_json::from_str(
+            r#"{"coin":"BTC","fundingRate":"0.0000125","premium":"0.0001","time":1625097600000}"#,
+        )
+        .unwrap();
+        assert_eq!(obj.get("time").and_then(Value::as_i64).unwrap(), 1625097600000);
+        let rate = dec(obj.get("fundingRate").and_then(Value::as_str).unwrap()).unwrap();
+        assert_eq!(rate, Decimal::from_str("0.0000125").unwrap());
+    }
+}

--- a/src/backtest/source/mod.rs
+++ b/src/backtest/source/mod.rs
@@ -1,0 +1,141 @@
+//! Historical-market-data providers behind a DRADIS-owned trait.
+//!
+//! Mirrors `helpers::llm_client::LlmChat` (runtime-selected backend, boxed once
+//! per run, one factory), NOT `venues::core::Execution` (compile-time static
+//! dispatch) — the data source is a per-CLI-invocation choice, not a build flavor.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::fetch::{Candle, FundingPoint}; // existing DTOs, unchanged
+
+pub mod binance;
+pub mod hyperliquid;
+
+pub use binance::BinanceSource;
+pub use hyperliquid::HyperliquidSource;
+
+/// DRADIS-owned contract for one historical-market-data provider (candles +
+/// funding history).
+///
+/// Implementors own ONLY the wire protocol: endpoint, request shape, their own
+/// pagination loop (caps/cursors/politeness delay), and field parsing into
+/// `Decimal`. Both current providers hit PUBLIC, unauthenticated endpoints —
+/// no API keys anywhere (Hyperliquid's info API has no auth field; Binance
+/// market data is IP-rate-limited and ignores keys). Caching (SQLite),
+/// coverage checks, and the "never persist a still-forming candle" rule live
+/// in `BacktestCache`, not here — that split is the whole point.
+///
+/// Future data kinds (e.g. open-interest history) are added as new trait
+/// methods with `Ok(Vec::new())`-style defaults, exactly like
+/// `Execution::open_orders`/`subscribe_fills` already do in `venues/core.rs`,
+/// so existing providers keep compiling.
+#[async_trait]
+pub trait HistoricalSource: Send + Sync {
+    /// Canonical lowercase id — the cache-key namespace (`source` column) and
+    /// the tag in logs/`report.json`. MUST be stable: renaming it orphans
+    /// previously cached rows under the old id (a harmless cache-miss/refetch,
+    /// not corruption — but for Hyperliquid, whose API retains only ~5000
+    /// candles, orphaned history is unrefetchable).
+    fn id(&self) -> &'static str;
+
+    /// Map a DRADIS coin symbol (e.g. "BTC" — `BacktestConfig::coin`) onto
+    /// this provider's native wire symbol (Hyperliquid: "BTC"; Binance FAPI:
+    /// "BTCUSDT"). Called ONLY inside `fetch_candles`/`fetch_funding` — the
+    /// cache and harness always key on the DRADIS coin, never the wire symbol,
+    /// so cache rows read the same ("BTC") regardless of `--source`.
+    fn resolve_symbol(&self, coin: &str) -> String;
+
+    /// This provider's native funding-rate cadence in hours (Hyperliquid = 1;
+    /// Binance FAPI majors = 8). Used by `synth::normalize_funding` to rescale
+    /// onto the canonical per-8h unit, and by `BacktestCache::load_funding`
+    /// for its coverage-slack math.
+    fn funding_period_hours(&self) -> u32;
+
+    /// Fetch every candle in `[start_ms, end_ms)` for `coin`/`interval`,
+    /// paginating internally per this provider's own limits. Ascending by
+    /// open-time `ts_ms`. MAY include the still-forming final bar — the cache
+    /// strips it on insert, not the provider.
+    async fn fetch_candles(
+        &self,
+        coin: &str,
+        interval: &str,
+        start_ms: i64,
+        end_ms: i64,
+    ) -> Result<Vec<Candle>>;
+
+    /// Fetch every funding observation in `[start_ms, end_ms)` for `coin`,
+    /// paginating internally, ascending. Rates are returned in the PROVIDER'S
+    /// NATIVE cadence — normalization happens in `synth::normalize_funding`.
+    async fn fetch_funding(&self, coin: &str, start_ms: i64, end_ms: i64)
+        -> Result<Vec<FundingPoint>>;
+}
+
+/// Which provider a backtest reads from. Runtime-selected per run via
+/// `--source` (CLI) or the HTTP API's `source` field — NOT a cargo feature:
+/// both backends are cheap HTTP+JSON with no SDK, so there is nothing to
+/// compile out. Derives `clap::ValueEnum` so the CLI and the HTTP API share
+/// ONE parser (`<SourceKind as clap::ValueEnum>::from_str(s, true)`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum SourceKind {
+    Hyperliquid,
+    Binance,
+}
+
+impl SourceKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SourceKind::Hyperliquid => "hyperliquid",
+            SourceKind::Binance => "binance",
+        }
+    }
+}
+
+/// The one factory — mirrors `llm_client::build_client`. Adding a provider =
+/// one enum variant + one file + one match arm.
+pub fn build_source(kind: SourceKind) -> Box<dyn HistoricalSource> {
+    match kind {
+        SourceKind::Hyperliquid => Box::new(HyperliquidSource::new()),
+        SourceKind::Binance => Box::new(BinanceSource::new()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::ValueEnum;
+
+    #[test]
+    fn source_kind_parses_case_insensitively_via_value_enum() {
+        assert_eq!(
+            <SourceKind as ValueEnum>::from_str("hyperliquid", true).unwrap(),
+            SourceKind::Hyperliquid
+        );
+        assert_eq!(
+            <SourceKind as ValueEnum>::from_str("HyperLiquid", true).unwrap(),
+            SourceKind::Hyperliquid
+        );
+        assert_eq!(
+            <SourceKind as ValueEnum>::from_str("BINANCE", true).unwrap(),
+            SourceKind::Binance
+        );
+        assert_eq!(
+            <SourceKind as ValueEnum>::from_str("binance", true).unwrap(),
+            SourceKind::Binance
+        );
+    }
+
+    #[test]
+    fn source_kind_rejects_unknown_value() {
+        assert!(<SourceKind as ValueEnum>::from_str("kraken", true).is_err());
+    }
+
+    #[test]
+    fn source_kind_as_str_round_trips_through_value_enum() {
+        for kind in SourceKind::value_variants() {
+            let parsed = <SourceKind as ValueEnum>::from_str(kind.as_str(), true).unwrap();
+            assert_eq!(parsed, *kind);
+        }
+    }
+
+}

--- a/src/backtest/synth.rs
+++ b/src/backtest/synth.rs
@@ -1,0 +1,280 @@
+//! W4 — Snapshot synthesizer: historical candles → `MarketSnapshot`.
+//!
+//! * **Kinematics** — 1m closes are fed through a shared `PriceKinematics` at 60s
+//!   synthetic steps, producing `oracle_drift_10m`/`drift_60m` faithfully (10/60
+//!   one-minute samples). `velocity_5s`/`velocity_1s` fall to ~0 because the 5s/1s
+//!   windows never contain a second sample at 60s spacing — velocity-gated logic is
+//!   therefore **Tier B** (approximate), as documented.
+//! * **Funding** — the HL HOURLY funding rate is normalized ×8 onto Binance's per-8h
+//!   scale via [`normalize_funding_8h`] (mirrors `raptors::hyperliquid`), then fed to
+//!   `snapshot.funding_rate`. Funding is a signal input only — binary shares pay no carry.
+//! * **Derivatives / tide** — `oi_delta_pct = cvd_ratio = institutional_pulse =
+//!   tide_coherence = 0`: no historical source. Convergence no-ops by design (Tier C).
+//! * **Polymarket book** — the 8 book fields come from [`book_model`], a pure,
+//!   unit-tested binary-option pricing of YES = P(finish above strike) with a
+//!   configurable half-spread and constant depth. Sweepable in isolation (Tier C).
+
+use std::collections::VecDeque;
+
+use chrono::{DateTime, Utc};
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+use crate::raptors::kinematics::PriceKinematics;
+use crate::state::MarketSnapshot;
+
+use super::clock::ReplayClock;
+use super::fetch::Candle;
+
+/// Normalize an HL HOURLY funding rate onto Binance's per-8h scale (×8), exactly as
+/// `raptors::hyperliquid::normalize_funding_8h` does. Re-implemented here (that fn is
+/// private AND behind the `hyperliquid` cargo feature, which `backtest` does not
+/// require) with its own test so the two can be diffed for drift.
+pub fn normalize_funding_8h(hourly: Decimal) -> Decimal {
+    hourly * dec!(8)
+}
+
+/// The 8 modeled Polymarket book fields for one tick.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BookQuote {
+    pub yes_bid: Decimal,
+    pub yes_ask: Decimal,
+    pub yes_bid_depth: Decimal,
+    pub yes_ask_depth: Decimal,
+    pub no_bid: Decimal,
+    pub no_ask: Decimal,
+    pub no_bid_depth: Decimal,
+    pub no_ask_depth: Decimal,
+}
+
+/// Standard normal CDF Φ(x) via a high-accuracy erf approximation
+/// (Abramowitz & Stegun 7.1.26; |error| < 1.5e-7).
+fn phi(x: f64) -> f64 {
+    // erf(z) with the A&S rational approximation.
+    fn erf(z: f64) -> f64 {
+        let sign = if z < 0.0 { -1.0 } else { 1.0 };
+        let z = z.abs();
+        let t = 1.0 / (1.0 + 0.3275911 * z);
+        let y = 1.0
+            - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t
+                + 0.254829592)
+                * t
+                * (-z * z).exp();
+        sign * y
+    }
+    0.5 * (1.0 + erf(x / std::f64::consts::SQRT_2))
+}
+
+fn clamp_prob(v: Decimal) -> Decimal {
+    v.clamp(dec!(0.01), dec!(0.99))
+}
+
+/// Pure binary-option book model. `sigma_per_min` is the per-minute log-return
+/// volatility; `tau_min` is minutes to expiry. YES mid = P(oracle finishes above
+/// strike) under a driftless log-normal, half-spread applied symmetrically, constant
+/// depth per side, all clamped to `[0.01, 0.99]`. With no strike or no vol/time it
+/// falls back to a 0.50 coin-flip mid.
+pub fn book_model(
+    oracle: Decimal,
+    strike: Option<Decimal>,
+    sigma_per_min: f64,
+    tau_min: f64,
+    half_spread: Decimal,
+    depth: Decimal,
+) -> BookQuote {
+    let yes_mid = match strike {
+        Some(k) if k > dec!(0) && sigma_per_min > 0.0 && tau_min > 0.0 => {
+            let o = oracle.to_f64().unwrap_or(0.0);
+            let kf = k.to_f64().unwrap_or(0.0);
+            if o > 0.0 && kf > 0.0 {
+                let vol = sigma_per_min * tau_min.sqrt();
+                let d = (o / kf).ln() / vol;
+                Decimal::from_f64_retain(phi(d)).unwrap_or(dec!(0.5))
+            } else {
+                dec!(0.5)
+            }
+        }
+        _ => dec!(0.5),
+    };
+    let yes_mid = clamp_prob(yes_mid);
+    let no_mid = dec!(1) - yes_mid;
+
+    BookQuote {
+        yes_bid: clamp_prob(yes_mid - half_spread),
+        yes_ask: clamp_prob(yes_mid + half_spread),
+        yes_bid_depth: depth,
+        yes_ask_depth: depth,
+        no_bid: clamp_prob(no_mid - half_spread),
+        no_ask: clamp_prob(no_mid + half_spread),
+        no_bid_depth: depth,
+        no_ask_depth: depth,
+    }
+}
+
+/// Builds one `MarketSnapshot` per replay tick from a shared kinematics accumulator,
+/// a trailing-close volatility window, and the configured book-model parameters.
+pub struct SnapshotSynthesizer {
+    kin: PriceKinematics,
+    closes: VecDeque<Decimal>,
+    sigma_window: usize,
+    half_spread: Decimal,
+    depth: Decimal,
+}
+
+impl SnapshotSynthesizer {
+    pub fn new(half_spread: Decimal, depth: Decimal, sigma_window: usize) -> Self {
+        Self {
+            kin: PriceKinematics::new(),
+            closes: VecDeque::new(),
+            sigma_window: sigma_window.max(2),
+            half_spread,
+            depth,
+        }
+    }
+
+    /// Estimate per-minute log-return volatility from the trailing close window.
+    fn sigma_per_min(&self) -> f64 {
+        if self.closes.len() < 2 {
+            return 0.0;
+        }
+        let mut rets: Vec<f64> = Vec::with_capacity(self.closes.len() - 1);
+        let mut prev: Option<f64> = None;
+        for c in &self.closes {
+            let v = c.to_f64().unwrap_or(0.0);
+            if let Some(p) = prev {
+                if p > 0.0 && v > 0.0 {
+                    rets.push((v / p).ln());
+                }
+            }
+            prev = Some(v);
+        }
+        if rets.len() < 2 {
+            return 0.0;
+        }
+        let mean = rets.iter().sum::<f64>() / rets.len() as f64;
+        let var = rets.iter().map(|r| (r - mean).powi(2)).sum::<f64>() / (rets.len() as f64 - 1.0);
+        var.sqrt()
+    }
+
+    /// Produce the `MarketSnapshot` for the candle at `candle.ts_ms`, given the
+    /// active market's `close_time`/`strike` and the (raw hourly) funding rate.
+    pub fn on_tick(
+        &mut self,
+        clock: &ReplayClock,
+        candle: &Candle,
+        market_close: DateTime<Utc>,
+        strike: Option<Decimal>,
+        funding_hourly: Decimal,
+    ) -> MarketSnapshot {
+        // Kinematics at 60s synthetic steps (drift faithful; velocity ~0 → Tier B).
+        let k = self
+            .kin
+            .on_price(clock.mono_tokio(candle.ts_ms), candle.close);
+
+        self.closes.push_back(candle.close);
+        while self.closes.len() > self.sigma_window {
+            self.closes.pop_front();
+        }
+
+        let secs_to_expiry = clock.secs_to_expiry(candle.ts_ms, market_close);
+        let tau_min = (secs_to_expiry.max(0) as f64) / 60.0;
+        let book = book_model(
+            candle.close,
+            strike,
+            self.sigma_per_min(),
+            tau_min,
+            self.half_spread,
+            self.depth,
+        );
+
+        MarketSnapshot {
+            yes_bid: book.yes_bid,
+            yes_bid_depth: book.yes_bid_depth,
+            yes_ask: book.yes_ask,
+            yes_ask_depth: book.yes_ask_depth,
+            no_bid: book.no_bid,
+            no_bid_depth: book.no_bid_depth,
+            no_ask: book.no_ask,
+            no_ask_depth: book.no_ask_depth,
+            oracle_price: candle.close,
+            velocity: k.velocity_5s,
+            velocity_1s: k.velocity_1s,
+            acceleration: k.acceleration,
+            funding_rate: normalize_funding_8h(funding_hourly),
+            // Tier C — no historical source; Convergence no-ops on these.
+            institutional_pulse: dec!(0),
+            tide_coherence: dec!(0),
+            oi_delta_pct: dec!(0),
+            cvd_ratio: dec!(0),
+            oracle_drift_60m: k.drift_60m,
+            oracle_drift_10m: k.drift_10m,
+            secs_to_expiry,
+            timestamp: clock.wall(candle.ts_ms),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn funding_normalized_x8_matches_raptor() {
+        assert_eq!(normalize_funding_8h(dec!(0.0000125)), dec!(0.0001));
+        assert_eq!(normalize_funding_8h(dec!(-0.0000125)), dec!(-0.0001));
+        assert_eq!(normalize_funding_8h(dec!(0)), dec!(0));
+    }
+
+    #[test]
+    fn phi_is_calibrated() {
+        assert!((phi(0.0) - 0.5).abs() < 1e-6);
+        assert!(phi(5.0) > 0.999);
+        assert!(phi(-5.0) < 0.001);
+        // Symmetry.
+        assert!((phi(1.0) + phi(-1.0) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn book_model_above_strike_favours_yes() {
+        let q = book_model(
+            Decimal::from_str("101000").unwrap(),
+            Some(Decimal::from_str("100000").unwrap()),
+            0.001,   // ~0.1%/min vol
+            30.0,    // 30 min to expiry
+            dec!(0.02),
+            dec!(500),
+        );
+        // Oracle above strike → YES mid > 0.5, so yes_ask well above no_ask.
+        assert!(q.yes_ask > q.no_ask);
+        assert!(q.yes_bid < q.yes_ask);
+        // Clamped into [0.01, 0.99].
+        assert!(q.yes_ask <= dec!(0.99) && q.yes_bid >= dec!(0.01));
+        assert_eq!(q.yes_bid_depth, dec!(500));
+    }
+
+    #[test]
+    fn book_model_no_strike_is_coinflip() {
+        let q = book_model(dec!(50000), None, 0.001, 30.0, dec!(0.02), dec!(500));
+        assert_eq!(q.yes_ask, dec!(0.52));
+        assert_eq!(q.yes_bid, dec!(0.48));
+        assert_eq!(q.no_ask, dec!(0.52));
+        assert_eq!(q.no_bid, dec!(0.48));
+    }
+
+    #[test]
+    fn book_model_clamps_extremes() {
+        // Deep in the money with high vol/time still clamps at 0.99/0.01.
+        let q = book_model(
+            Decimal::from_str("200000").unwrap(),
+            Some(Decimal::from_str("100000").unwrap()),
+            0.0005,
+            10.0,
+            dec!(0.02),
+            dec!(500),
+        );
+        assert!(q.yes_ask <= dec!(0.99));
+        assert!(q.no_bid >= dec!(0.01));
+    }
+}

--- a/src/backtest/synth.rs
+++ b/src/backtest/synth.rs
@@ -5,9 +5,11 @@
 //!   one-minute samples). `velocity_5s`/`velocity_1s` fall to ~0 because the 5s/1s
 //!   windows never contain a second sample at 60s spacing — velocity-gated logic is
 //!   therefore **Tier B** (approximate), as documented.
-//! * **Funding** — the HL HOURLY funding rate is normalized ×8 onto Binance's per-8h
-//!   scale via [`normalize_funding_8h`] (mirrors `raptors::hyperliquid`), then fed to
-//!   `snapshot.funding_rate`. Funding is a signal input only — binary shares pay no carry.
+//! * **Funding** — the provider-native funding rate is rescaled onto Binance's per-8h
+//!   scale via [`normalize_funding`] (generalized from the HL-only ×8 rescale that
+//!   [`normalize_funding_8h`] still performs as a back-compat alias; mirrors
+//!   `raptors::hyperliquid`), then fed to `snapshot.funding_rate`. Funding is a signal
+//!   input only — binary shares pay no carry.
 //! * **Derivatives / tide** — `oi_delta_pct = cvd_ratio = institutional_pulse =
 //!   tide_coherence = 0`: no historical source. Convergence no-ops by design (Tier C).
 //! * **Polymarket book** — the 8 book fields come from [`book_model`], a pure,
@@ -27,12 +29,23 @@ use crate::state::MarketSnapshot;
 use super::clock::ReplayClock;
 use super::fetch::Candle;
 
-/// Normalize an HL HOURLY funding rate onto Binance's per-8h scale (×8), exactly as
+/// Normalize a provider-native funding rate onto Binance's canonical per-8h
+/// scale. `period_hours` is the provider's native cadence
+/// (`HistoricalSource::funding_period_hours`: Hyperliquid = 1, Binance = 8).
+pub fn normalize_funding(rate: Decimal, period_hours: u32) -> Decimal {
+    if period_hours == 8 {
+        return rate; // already at target scale — avoid needless 8/8 arithmetic
+    }
+    rate * Decimal::from(8u32) / Decimal::from(period_hours.max(1))
+}
+
+/// Back-compat alias (HL hourly ×8), exactly as
 /// `raptors::hyperliquid::normalize_funding_8h` does. Re-implemented here (that fn is
 /// private AND behind the `hyperliquid` cargo feature, which `backtest` does not
-/// require) with its own test so the two can be diffed for drift.
+/// require) — keeps every existing call site and the drift-check test vs
+/// `raptors::hyperliquid`'s private copy compiling as-is.
 pub fn normalize_funding_8h(hourly: Decimal) -> Decimal {
-    hourly * dec!(8)
+    normalize_funding(hourly, 1)
 }
 
 /// The 8 modeled Polymarket book fields for one tick.
@@ -158,14 +171,16 @@ impl SnapshotSynthesizer {
     }
 
     /// Produce the `MarketSnapshot` for the candle at `candle.ts_ms`, given the
-    /// active market's `close_time`/`strike` and the (raw hourly) funding rate.
+    /// active market's `close_time`/`strike` and the (raw, provider-native cadence)
+    /// funding rate.
     pub fn on_tick(
         &mut self,
         clock: &ReplayClock,
         candle: &Candle,
         market_close: DateTime<Utc>,
         strike: Option<Decimal>,
-        funding_hourly: Decimal,
+        funding_native: Decimal,
+        funding_period_hours: u32,
     ) -> MarketSnapshot {
         // Kinematics at 60s synthetic steps (drift faithful; velocity ~0 → Tier B).
         let k = self
@@ -201,7 +216,7 @@ impl SnapshotSynthesizer {
             velocity: k.velocity_5s,
             velocity_1s: k.velocity_1s,
             acceleration: k.acceleration,
-            funding_rate: normalize_funding_8h(funding_hourly),
+            funding_rate: normalize_funding(funding_native, funding_period_hours),
             // Tier C — no historical source; Convergence no-ops on these.
             institutional_pulse: dec!(0),
             tide_coherence: dec!(0),
@@ -225,6 +240,22 @@ mod tests {
         assert_eq!(normalize_funding_8h(dec!(0.0000125)), dec!(0.0001));
         assert_eq!(normalize_funding_8h(dec!(-0.0000125)), dec!(-0.0001));
         assert_eq!(normalize_funding_8h(dec!(0)), dec!(0));
+    }
+
+    #[test]
+    fn normalize_funding_identity_at_target_cadence() {
+        // period_hours == 8 is already the canonical scale — pass-through.
+        assert_eq!(normalize_funding(dec!(0.0001), 8), dec!(0.0001));
+        assert_eq!(normalize_funding(dec!(-0.0001), 8), dec!(-0.0001));
+        assert_eq!(normalize_funding(dec!(0), 8), dec!(0));
+    }
+
+    #[test]
+    fn normalize_funding_scales_hourly_rate_by_8() {
+        // period_hours == 1 (Hyperliquid) rescales onto the per-8h target.
+        assert_eq!(normalize_funding(dec!(0.0000125), 1), dec!(0.0001));
+        assert_eq!(normalize_funding(dec!(-0.0000125), 1), dec!(-0.0001));
+        assert_eq!(normalize_funding(dec!(0), 1), dec!(0));
     }
 
     #[test]

--- a/src/bin/backtest.rs
+++ b/src/bin/backtest.rs
@@ -1,0 +1,151 @@
+//! W8 — `backtest` CLI (feature-gated; `required-features = ["backtest"]`).
+//!
+//! Replays historical Hyperliquid data through the REAL viper strategies and prints a
+//! per-strategy summary + native Decimal PnL + rs-backtester directional-proxy metrics
+//! + an honest fidelity-tier disclaimer.
+//!
+//! Usage:
+//!   cargo run --features backtest --bin backtest -- \
+//!     --coin BTC --start <rfc3339|unix|now-6h> --end <…|now-1h> \
+//!     [--interval 1m] [--strategies momentum,trendreversal] \
+//!     [--spread 0.02] [--depth 500] [--commission 0.0] \
+//!     [--llm-score] [--cache backtest_cache.sqlite] [--out backtest_out]
+
+use std::str::FromStr;
+
+use anyhow::{anyhow, bail, Context, Result};
+use rust_decimal::Decimal;
+
+use dradis::backtest::entry::parse_time;
+use dradis::backtest::harness::{run_backtest, BacktestConfig};
+use dradis::backtest::report::{print_summary, run_rs_backtester, write_native};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .init();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        print_usage();
+        return Ok(());
+    }
+
+    let mut coin: Option<String> = None;
+    let mut start: Option<String> = None;
+    let mut end: Option<String> = None;
+    let mut interval = "1m".to_string();
+    let mut strategies: Option<Vec<String>> = None;
+    let mut spread = Decimal::from_str("0.02").unwrap();
+    let mut depth = Decimal::from_str("500").unwrap();
+    let mut commission = Decimal::ZERO;
+    let mut llm_score = false;
+    let mut cache = "backtest_cache.sqlite".to_string();
+    let mut out = "backtest_out".to_string();
+    let mut starting = Decimal::from_str("500").unwrap();
+
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i].clone();
+        match a.as_str() {
+            "--coin" => coin = Some(val(&args, &mut i, "--coin")?),
+            "--start" => start = Some(val(&args, &mut i, "--start")?),
+            "--end" => end = Some(val(&args, &mut i, "--end")?),
+            "--interval" => interval = val(&args, &mut i, "--interval")?,
+            "--strategies" => {
+                strategies = Some(
+                    val(&args, &mut i, "--strategies")?
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect(),
+                )
+            }
+            "--spread" => spread = Decimal::from_str(&val(&args, &mut i, "--spread")?).context("--spread")?,
+            "--depth" => depth = Decimal::from_str(&val(&args, &mut i, "--depth")?).context("--depth")?,
+            "--commission" => {
+                commission = Decimal::from_str(&val(&args, &mut i, "--commission")?).context("--commission")?
+            }
+            "--starting" => {
+                starting = Decimal::from_str(&val(&args, &mut i, "--starting")?).context("--starting")?
+            }
+            "--llm-score" => llm_score = true,
+            "--cache" => cache = val(&args, &mut i, "--cache")?,
+            "--out" => out = val(&args, &mut i, "--out")?,
+            other => bail!("unknown argument: {other} (try --help)"),
+        }
+        i += 1;
+    }
+
+    let coin = coin.ok_or_else(|| anyhow!("--coin is required (e.g. --coin BTC)"))?.to_uppercase();
+    let start_ms = parse_time(&start.ok_or_else(|| anyhow!("--start is required"))?)?;
+    let end_ms = parse_time(&end.ok_or_else(|| anyhow!("--end is required"))?)?;
+    if end_ms <= start_ms {
+        bail!("--end ({end_ms}) must be after --start ({start_ms})");
+    }
+
+    let cfg = BacktestConfig {
+        crypto_filter: coin.to_lowercase(),
+        coin,
+        interval,
+        start_ms,
+        end_ms,
+        strategies,
+        half_spread: spread,
+        depth,
+        commission,
+        starting_collateral: starting,
+        llm_score,
+        cache_path: cache,
+        out_dir: out,
+        sigma_window: 60,
+    };
+
+    let outcome = run_backtest(&cfg).await?;
+    let rs = run_rs_backtester(
+        &cfg.coin,
+        &outcome.candles,
+        &outcome.stances,
+        cfg.commission,
+        dradis::backtest::bridge::dec_to_f64(cfg.starting_collateral),
+    );
+    write_native(&cfg, &outcome, &rs)?;
+    print_summary(&cfg, &outcome, &rs);
+    Ok(())
+}
+
+/// Consume and return the value following a flag at `args[*i]`, advancing `*i`.
+fn val(args: &[String], i: &mut usize, flag: &str) -> Result<String> {
+    *i += 1;
+    args.get(*i)
+        .cloned()
+        .ok_or_else(|| anyhow!("missing value for {flag}"))
+}
+
+fn print_usage() {
+    println!(
+        "DRADIS backtest — replay historical Hyperliquid data through the real vipers.\n\
+\n\
+REQUIRED:\n\
+  --coin BTC              Hyperliquid coin symbol\n\
+  --start <t>             rfc3339 | unix(s|ms) | now-6h\n\
+  --end <t>               rfc3339 | unix(s|ms) | now-1h\n\
+\n\
+OPTIONAL:\n\
+  --interval 1m           candle interval (default 1m)\n\
+  --strategies a,b        subset by short name (momentum,trendreversal,gboost,basis,\n\
+                          maker,timedecay,arbitrage,convergence); default = all\n\
+  --spread 0.02           book-model half-spread (Tier C)\n\
+  --depth 500             modeled depth, shares/side (Tier C)\n\
+  --commission 0.0        fee rate (native ledger + rs-backtester proxy)\n\
+  --starting 500          starting collateral ($)\n\
+  --llm-score             experimental: LLM conviction scoring (needs a provider)\n\
+  --cache <path>          backtest SQLite cache (default backtest_cache.sqlite)\n\
+  --out <dir>             output dir for report.json/trades.csv/equity.csv\n"
+    );
+}

--- a/src/bin/backtest.rs
+++ b/src/bin/backtest.rs
@@ -1,24 +1,89 @@
 //! W8 — `backtest` CLI (feature-gated; `required-features = ["backtest"]`).
 //!
-//! Replays historical Hyperliquid data through the REAL viper strategies and prints a
-//! per-strategy summary + native Decimal PnL + rs-backtester directional-proxy metrics
-//! + an honest fidelity-tier disclaimer.
+//! Replays historical market data (Hyperliquid or Binance FAPI, via `--source`) through
+//! the REAL viper strategies and prints a per-strategy summary + native Decimal PnL +
+//! rs-backtester directional-proxy metrics + an honest fidelity-tier disclaimer.
 //!
 //! Usage:
 //!   cargo run --features backtest --bin backtest -- \
 //!     --coin BTC --start <rfc3339|unix|now-6h> --end <…|now-1h> \
 //!     [--interval 1m] [--strategies momentum,trendreversal] \
-//!     [--spread 0.02] [--depth 500] [--commission 0.0] \
-//!     [--llm-score] [--cache backtest_cache.sqlite] [--out backtest_out]
+//!     [--spread 0.02] [--depth 500] [--commission 0.0] [--starting 500] \
+//!     [--llm-score] [--cache backtest_cache.sqlite] [--out backtest_out] \
+//!     [--source hyperliquid|binance]
 
 use std::str::FromStr;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Result};
+use clap::Parser;
 use rust_decimal::Decimal;
 
 use dradis::backtest::entry::parse_time;
 use dradis::backtest::harness::{run_backtest, BacktestConfig};
 use dradis::backtest::report::{print_summary, run_rs_backtester, write_native};
+use dradis::backtest::source::SourceKind;
+
+/// DRADIS backtest — replay historical market data through the real vipers.
+#[derive(Parser, Debug)]
+#[command(name = "backtest", version, about)]
+struct Cli {
+    /// Coin symbol, e.g. BTC (DRADIS asset — mapped to the provider's wire symbol per --source)
+    #[arg(long)]
+    coin: String,
+
+    /// rfc3339 | unix(s|ms) | now-6h
+    #[arg(long)]
+    start: String,
+
+    /// rfc3339 | unix(s|ms) | now-1h
+    #[arg(long)]
+    end: String,
+
+    /// Candle interval (default 1m)
+    #[arg(long, default_value = "1m")]
+    interval: String,
+
+    /// Subset by short name (momentum,trendreversal,gboost,basis,maker,timedecay,
+    /// arbitrage,convergence); comma-separated; default = all
+    #[arg(long, value_delimiter = ',')]
+    strategies: Option<Vec<String>>,
+
+    /// Book-model half-spread (Tier C)
+    #[arg(long, default_value = "0.02", value_parser = parse_decimal, allow_negative_numbers = true)]
+    spread: Decimal,
+
+    /// Modeled depth, shares/side (Tier C)
+    #[arg(long, default_value = "500", value_parser = parse_decimal, allow_negative_numbers = true)]
+    depth: Decimal,
+
+    /// Fee rate (native ledger + rs-backtester proxy)
+    #[arg(long, default_value = "0", value_parser = parse_decimal, allow_negative_numbers = true)]
+    commission: Decimal,
+
+    /// Starting collateral ($)
+    #[arg(long, default_value = "500", value_parser = parse_decimal, allow_negative_numbers = true)]
+    starting: Decimal,
+
+    /// Experimental: LLM conviction scoring (needs a provider)
+    #[arg(long)]
+    llm_score: bool,
+
+    /// Backtest SQLite cache path
+    #[arg(long, default_value = "backtest_cache.sqlite")]
+    cache: String,
+
+    /// Output dir for report.json/trades.csv/equity.csv
+    #[arg(long, default_value = "backtest_out")]
+    out: String,
+
+    /// Historical-data provider (both hit public, unauthenticated endpoints — no key needed)
+    #[arg(long, value_enum, default_value_t = SourceKind::Hyperliquid)]
+    source: SourceKind,
+}
+
+fn parse_decimal(s: &str) -> Result<Decimal, String> {
+    Decimal::from_str(s).map_err(|e| e.to_string())
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -30,80 +95,40 @@ async fn main() -> Result<()> {
         .with_target(false)
         .init();
 
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    if args.iter().any(|a| a == "-h" || a == "--help") {
-        print_usage();
-        return Ok(());
-    }
-
-    let mut coin: Option<String> = None;
-    let mut start: Option<String> = None;
-    let mut end: Option<String> = None;
-    let mut interval = "1m".to_string();
-    let mut strategies: Option<Vec<String>> = None;
-    let mut spread = Decimal::from_str("0.02").unwrap();
-    let mut depth = Decimal::from_str("500").unwrap();
-    let mut commission = Decimal::ZERO;
-    let mut llm_score = false;
-    let mut cache = "backtest_cache.sqlite".to_string();
-    let mut out = "backtest_out".to_string();
-    let mut starting = Decimal::from_str("500").unwrap();
-
-    let mut i = 0;
-    while i < args.len() {
-        let a = args[i].clone();
-        match a.as_str() {
-            "--coin" => coin = Some(val(&args, &mut i, "--coin")?),
-            "--start" => start = Some(val(&args, &mut i, "--start")?),
-            "--end" => end = Some(val(&args, &mut i, "--end")?),
-            "--interval" => interval = val(&args, &mut i, "--interval")?,
-            "--strategies" => {
-                strategies = Some(
-                    val(&args, &mut i, "--strategies")?
-                        .split(',')
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect(),
-                )
-            }
-            "--spread" => spread = Decimal::from_str(&val(&args, &mut i, "--spread")?).context("--spread")?,
-            "--depth" => depth = Decimal::from_str(&val(&args, &mut i, "--depth")?).context("--depth")?,
-            "--commission" => {
-                commission = Decimal::from_str(&val(&args, &mut i, "--commission")?).context("--commission")?
-            }
-            "--starting" => {
-                starting = Decimal::from_str(&val(&args, &mut i, "--starting")?).context("--starting")?
-            }
-            "--llm-score" => llm_score = true,
-            "--cache" => cache = val(&args, &mut i, "--cache")?,
-            "--out" => out = val(&args, &mut i, "--out")?,
-            other => bail!("unknown argument: {other} (try --help)"),
-        }
-        i += 1;
-    }
-
-    let coin = coin.ok_or_else(|| anyhow!("--coin is required (e.g. --coin BTC)"))?.to_uppercase();
-    let start_ms = parse_time(&start.ok_or_else(|| anyhow!("--start is required"))?)?;
-    let end_ms = parse_time(&end.ok_or_else(|| anyhow!("--end is required"))?)?;
+    let cli = Cli::parse();
+    let coin = cli.coin.to_uppercase();
+    let start_ms = parse_time(&cli.start)?;
+    let end_ms = parse_time(&cli.end)?;
     if end_ms <= start_ms {
         bail!("--end ({end_ms}) must be after --start ({start_ms})");
     }
+    // NOTE: an effectively-empty `--strategies ""` stays `Some(vec![])` — "run
+    // NOTHING" — exactly like the pre-clap parser (configure_enables disables all
+    // strategies for an empty subset). Do not collapse it to `None`, which would
+    // silently invert it into "run everything".
+    let strategies = cli.strategies.map(|v| {
+        v.into_iter()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+    });
 
     let cfg = BacktestConfig {
         crypto_filter: coin.to_lowercase(),
         coin,
-        interval,
+        interval: cli.interval,
         start_ms,
         end_ms,
         strategies,
-        half_spread: spread,
-        depth,
-        commission,
-        starting_collateral: starting,
-        llm_score,
-        cache_path: cache,
-        out_dir: out,
+        half_spread: cli.spread,
+        depth: cli.depth,
+        commission: cli.commission,
+        starting_collateral: cli.starting,
+        llm_score: cli.llm_score,
+        cache_path: cli.cache,
+        out_dir: cli.out,
         sigma_window: 60,
+        source: cli.source,
     };
 
     let outcome = run_backtest(&cfg).await?;
@@ -117,35 +142,4 @@ async fn main() -> Result<()> {
     write_native(&cfg, &outcome, &rs)?;
     print_summary(&cfg, &outcome, &rs);
     Ok(())
-}
-
-/// Consume and return the value following a flag at `args[*i]`, advancing `*i`.
-fn val(args: &[String], i: &mut usize, flag: &str) -> Result<String> {
-    *i += 1;
-    args.get(*i)
-        .cloned()
-        .ok_or_else(|| anyhow!("missing value for {flag}"))
-}
-
-fn print_usage() {
-    println!(
-        "DRADIS backtest — replay historical Hyperliquid data through the real vipers.\n\
-\n\
-REQUIRED:\n\
-  --coin BTC              Hyperliquid coin symbol\n\
-  --start <t>             rfc3339 | unix(s|ms) | now-6h\n\
-  --end <t>               rfc3339 | unix(s|ms) | now-1h\n\
-\n\
-OPTIONAL:\n\
-  --interval 1m           candle interval (default 1m)\n\
-  --strategies a,b        subset by short name (momentum,trendreversal,gboost,basis,\n\
-                          maker,timedecay,arbitrage,convergence); default = all\n\
-  --spread 0.02           book-model half-spread (Tier C)\n\
-  --depth 500             modeled depth, shares/side (Tier C)\n\
-  --commission 0.0        fee rate (native ledger + rs-backtester proxy)\n\
-  --starting 500          starting collateral ($)\n\
-  --llm-score             experimental: LLM conviction scoring (needs a provider)\n\
-  --cache <path>          backtest SQLite cache (default backtest_cache.sqlite)\n\
-  --out <dir>             output dir for report.json/trades.csv/equity.csv\n"
-    );
 }

--- a/src/cag/session.rs
+++ b/src/cag/session.rs
@@ -61,7 +61,22 @@ pub struct SessionState {
     pub pending_orders: Arc<Mutex<HashMap<(String, MarketId), Instant>>>,
 
     /// Accumulated session P&L (realised on confirmed exits).
+    ///
+    /// LIVE-ONLY: since paper trading was split out, ghost exits/settlements no
+    /// longer book here — they book into [`Self::paper_pnl`]. This makes the
+    /// headline session P&L a clean live-money figure.
     pub total_pnl: Arc<Mutex<Decimal>>,
+
+    /// Accumulated *paper* (ghost) session P&L — realised on simulated ghost
+    /// exits and expiry settlements. Segregated from `total_pnl` so live and
+    /// paper track records never commingle.
+    pub paper_pnl: Arc<Mutex<Decimal>>,
+
+    /// Simulated paper collateral ledger, seeded from
+    /// `config::PAPER_STARTING_COLLATERAL`. Ghost entries debit their cost (and
+    /// are rejected when the ledger is insufficient); ghost exits and expiry
+    /// settlements credit their proceeds. Never touches real pUSD.
+    pub paper_balance: Arc<Mutex<Decimal>>,
 
     /// Live pUSD collateral balance polled from the CLOB API every ~60 s.
     /// Strategies read this to self-gate on insufficient funds before placing
@@ -146,6 +161,8 @@ impl SessionState {
             positions:            Arc::new(Mutex::new(PositionMap::new())),
             pending_orders:       Arc::new(Mutex::new(HashMap::new())),
             total_pnl:            Arc::new(Mutex::new(dec!(0))),
+            paper_pnl:            Arc::new(Mutex::new(dec!(0))),
+            paper_balance:        Arc::new(Mutex::new(crate::config::PAPER_STARTING_COLLATERAL)),
             live_collateral:      Arc::new(Mutex::new(startup_balance)),
             starting_collateral:  Arc::new(Mutex::new(startup_balance)),
             phantom_cooldowns:    Arc::new(Mutex::new(HashMap::new())),

--- a/src/config.aggressive.rs.example
+++ b/src/config.aggressive.rs.example
@@ -29,7 +29,31 @@ pub const ENABLE_X: bool = false;
 // ARBITRAGE STRATEGY PARAMETERS
 // ============================================================================
 
+/// Seed value for the runtime GHOST/LIVE toggle only.
+///
+/// This constant seeds `DynamicConfig.ghost_mode` on first boot and is recorded in
+/// the startup config-history snapshot. It NO LONGER gates order placement at
+/// runtime: the intl_clob patrol reads the hot-patchable `DynamicConfig`/
+/// `OrderParams.ghost_mode` (Control Tower GHOST/LIVE toggle) for new entries, and
+/// each open position permanently carries the mode it was opened under. Editing
+/// this value changes only the initial toggle state, not live behaviour mid-session.
 pub const GHOST_MODE: bool = false;
+
+/// Paper (ghost) trading starting collateral, in pUSD. The simulated ledger is
+/// seeded with this amount; ghost entries debit their cost and are rejected when
+/// the ledger is insufficient, ghost exits/settlements credit their proceeds.
+pub const PAPER_STARTING_COLLATERAL: Decimal = dec!(1000);
+
+/// Extra slippage applied to the depth-overflow tranche of a simulated (ghost)
+/// taker fill — the portion of an order that exceeds the best-level depth. Added
+/// to the ask on entries and subtracted from the bid on exits.
+pub const PAPER_OVERFLOW_SLIPPAGE: Decimal = dec!(0.02);
+
+/// Consecutive patrol ticks a simulated (ghost) resting maker BUY quote must be at
+/// or above the market's best bid before it is treated as filled — a documented
+/// queue-position heuristic replacing the old instant maker fill.
+pub const PAPER_MAKER_FILL_TICKS: u64 = 3;
+
 pub const ENABLE_ARBITRAGE_TRADING: bool = true;
 
 pub const ARBITRAGE_PROFIT_THRESHOLD: Decimal = dec!(0.012);
@@ -289,6 +313,18 @@ pub const DERIVATIVES_POLL_SECS: u64 = 30;
 pub const DERIV_GATE_ENABLED: bool = false;
 pub const DERIV_CVD_CONFIRM_MARGIN: Decimal = dec!(0.15);
 pub const DERIV_OI_UNWIND_BLOCK: Decimal = dec!(-0.05);
+
+// ============================================================================
+// MARKET DATA SOURCE
+// ============================================================================
+// Which external source feeds the raptor layer (spot price, velocity, funding,
+// open interest, taker flow). `binance` (default) uses Binance Spot WS + FAPI
+// REST; `hyperliquid` uses the Hyperliquid Info API (one WS raptor per asset,
+// trades → oracle/velocity/CVD, activeAssetCtx → funding(×8)/OI). The env var
+// MARKET_DATA_SOURCE overrides this. `hyperliquid` requires the default cargo
+// features (the SDK is gated behind the additive `hyperliquid` feature); without
+// it the engine logs an error and falls back to Binance.
+pub const MARKET_DATA_SOURCE: &str = "binance";  // binance | hyperliquid (env MARKET_DATA_SOURCE overrides)
 
 // ============================================================================
 // TIDE RAPTOR — "Institutional Pulse" spot-BTC-ETF premium signal
@@ -722,6 +758,25 @@ pub const LLM_OLLAMA_URL: &str = "http://localhost:11434";
 
 /// Default Ollama model.  Override with `OLLAMA_MODEL` env var.
 pub const LLM_OLLAMA_MODEL: &str = "llama3.2";
+
+/// LLM provider backend for the advisor: ollama | anthropic | openai |
+/// openai-compatible | chatgpt.  Default `ollama` preserves the historical
+/// behaviour (local/remote Ollama).  Override with the `LLM_PROVIDER` env var.
+pub const LLM_PROVIDER: &str = "ollama";
+
+/// Generic model name for the selected provider.  "" = use `LLM_OLLAMA_MODEL`
+/// for ollama, otherwise the provider's own default.  Override with `LLM_MODEL`.
+pub const LLM_MODEL: &str = "";
+
+/// Generic base-URL override (ollama / openai-compatible / optional openai or
+/// anthropic override).  "" = provider default (ollama falls back to
+/// `LLM_OLLAMA_URL`).  Override with `LLM_BASE_URL`.
+pub const LLM_BASE_URL: &str = "";
+
+/// Inference timeout (seconds) for CLOUD providers
+/// (anthropic / openai / openai-compatible / chatgpt).  Ollama keeps using
+/// `LLM_INFERENCE_TIMEOUT_SECS` because local CPU inference is much slower.
+pub const LLM_CLOUD_TIMEOUT_SECS: u64 = 120;
 
 
 // ============================================================================

--- a/src/config.balanced.rs.example
+++ b/src/config.balanced.rs.example
@@ -27,7 +27,31 @@ pub const ENABLE_X: bool = false;
 // ARBITRAGE STRATEGY PARAMETERS
 // ============================================================================
 
+/// Seed value for the runtime GHOST/LIVE toggle only.
+///
+/// This constant seeds `DynamicConfig.ghost_mode` on first boot and is recorded in
+/// the startup config-history snapshot. It NO LONGER gates order placement at
+/// runtime: the intl_clob patrol reads the hot-patchable `DynamicConfig`/
+/// `OrderParams.ghost_mode` (Control Tower GHOST/LIVE toggle) for new entries, and
+/// each open position permanently carries the mode it was opened under. Editing
+/// this value changes only the initial toggle state, not live behaviour mid-session.
 pub const GHOST_MODE: bool = false;
+
+/// Paper (ghost) trading starting collateral, in pUSD. The simulated ledger is
+/// seeded with this amount; ghost entries debit their cost and are rejected when
+/// the ledger is insufficient, ghost exits/settlements credit their proceeds.
+pub const PAPER_STARTING_COLLATERAL: Decimal = dec!(1000);
+
+/// Extra slippage applied to the depth-overflow tranche of a simulated (ghost)
+/// taker fill — the portion of an order that exceeds the best-level depth. Added
+/// to the ask on entries and subtracted from the bid on exits.
+pub const PAPER_OVERFLOW_SLIPPAGE: Decimal = dec!(0.02);
+
+/// Consecutive patrol ticks a simulated (ghost) resting maker BUY quote must be at
+/// or above the market's best bid before it is treated as filled — a documented
+/// queue-position heuristic replacing the old instant maker fill.
+pub const PAPER_MAKER_FILL_TICKS: u64 = 3;
+
 pub const ENABLE_ARBITRAGE_TRADING: bool = true;
 
 /// Min net profit after fees to trigger arbitrage.
@@ -280,6 +304,18 @@ pub const DERIVATIVES_POLL_SECS: u64 = 30;
 pub const DERIV_GATE_ENABLED: bool = false;
 pub const DERIV_CVD_CONFIRM_MARGIN: Decimal = dec!(0.15);
 pub const DERIV_OI_UNWIND_BLOCK: Decimal = dec!(-0.05);
+
+// ============================================================================
+// MARKET DATA SOURCE
+// ============================================================================
+// Which external source feeds the raptor layer (spot price, velocity, funding,
+// open interest, taker flow). `binance` (default) uses Binance Spot WS + FAPI
+// REST; `hyperliquid` uses the Hyperliquid Info API (one WS raptor per asset,
+// trades → oracle/velocity/CVD, activeAssetCtx → funding(×8)/OI). The env var
+// MARKET_DATA_SOURCE overrides this. `hyperliquid` requires the default cargo
+// features (the SDK is gated behind the additive `hyperliquid` feature); without
+// it the engine logs an error and falls back to Binance.
+pub const MARKET_DATA_SOURCE: &str = "binance";  // binance | hyperliquid (env MARKET_DATA_SOURCE overrides)
 
 // ============================================================================
 // TIDE RAPTOR — "Institutional Pulse" spot-BTC-ETF premium signal
@@ -698,6 +734,25 @@ pub const LLM_OLLAMA_URL: &str = "http://localhost:11434";
 
 /// Default Ollama model.  Override with `OLLAMA_MODEL` env var.
 pub const LLM_OLLAMA_MODEL: &str = "llama3.2";
+
+/// LLM provider backend for the advisor: ollama | anthropic | openai |
+/// openai-compatible | chatgpt.  Default `ollama` preserves the historical
+/// behaviour (local/remote Ollama).  Override with the `LLM_PROVIDER` env var.
+pub const LLM_PROVIDER: &str = "ollama";
+
+/// Generic model name for the selected provider.  "" = use `LLM_OLLAMA_MODEL`
+/// for ollama, otherwise the provider's own default.  Override with `LLM_MODEL`.
+pub const LLM_MODEL: &str = "";
+
+/// Generic base-URL override (ollama / openai-compatible / optional openai or
+/// anthropic override).  "" = provider default (ollama falls back to
+/// `LLM_OLLAMA_URL`).  Override with `LLM_BASE_URL`.
+pub const LLM_BASE_URL: &str = "";
+
+/// Inference timeout (seconds) for CLOUD providers
+/// (anthropic / openai / openai-compatible / chatgpt).  Ollama keeps using
+/// `LLM_INFERENCE_TIMEOUT_SECS` because local CPU inference is much slower.
+pub const LLM_CLOUD_TIMEOUT_SECS: u64 = 120;
 
 
 // ============================================================================

--- a/src/config.conservative.rs.example
+++ b/src/config.conservative.rs.example
@@ -26,9 +26,32 @@ pub const ENABLE_X: bool = false;
 // ARBITRAGE STRATEGY PARAMETERS
 // ============================================================================
 
-/// Dry-run mode — logs trades without executing them on-chain.
-/// ⚠️ Set to `false` only after validating signals in ghost mode for 30+ minutes.
+/// Seed value for the runtime GHOST/LIVE toggle only.
+///
+/// This constant seeds `DynamicConfig.ghost_mode` on first boot and is recorded in
+/// the startup config-history snapshot. It NO LONGER gates order placement at
+/// runtime: the intl_clob patrol reads the hot-patchable `DynamicConfig`/
+/// `OrderParams.ghost_mode` (Control Tower GHOST/LIVE toggle) for new entries, and
+/// each open position permanently carries the mode it was opened under. Editing
+/// this value changes only the initial toggle state, not live behaviour mid-session.
+/// ⚠️ Validate signals in ghost mode for 30+ minutes before flipping the runtime toggle to LIVE.
 pub const GHOST_MODE: bool = false;
+
+/// Paper (ghost) trading starting collateral, in pUSD. The simulated ledger is
+/// seeded with this amount; ghost entries debit their cost and are rejected when
+/// the ledger is insufficient, ghost exits/settlements credit their proceeds.
+pub const PAPER_STARTING_COLLATERAL: Decimal = dec!(1000);
+
+/// Extra slippage applied to the depth-overflow tranche of a simulated (ghost)
+/// taker fill — the portion of an order that exceeds the best-level depth. Added
+/// to the ask on entries and subtracted from the bid on exits.
+pub const PAPER_OVERFLOW_SLIPPAGE: Decimal = dec!(0.02);
+
+/// Consecutive patrol ticks a simulated (ghost) resting maker BUY quote must be at
+/// or above the market's best bid before it is treated as filled — a documented
+/// queue-position heuristic replacing the old instant maker fill.
+pub const PAPER_MAKER_FILL_TICKS: u64 = 3;
+
 pub const ENABLE_ARBITRAGE_TRADING: bool = true;
 
 /// Requires a wider margin before entering arbitrage — fewer trades, higher quality.
@@ -304,6 +327,18 @@ pub const DERIVATIVES_POLL_SECS: u64 = 30;
 pub const DERIV_GATE_ENABLED: bool = false;
 pub const DERIV_CVD_CONFIRM_MARGIN: Decimal = dec!(0.15);
 pub const DERIV_OI_UNWIND_BLOCK: Decimal = dec!(-0.05);
+
+// ============================================================================
+// MARKET DATA SOURCE
+// ============================================================================
+// Which external source feeds the raptor layer (spot price, velocity, funding,
+// open interest, taker flow). `binance` (default) uses Binance Spot WS + FAPI
+// REST; `hyperliquid` uses the Hyperliquid Info API (one WS raptor per asset,
+// trades → oracle/velocity/CVD, activeAssetCtx → funding(×8)/OI). The env var
+// MARKET_DATA_SOURCE overrides this. `hyperliquid` requires the default cargo
+// features (the SDK is gated behind the additive `hyperliquid` feature); without
+// it the engine logs an error and falls back to Binance.
+pub const MARKET_DATA_SOURCE: &str = "binance";  // binance | hyperliquid (env MARKET_DATA_SOURCE overrides)
 
 // ============================================================================
 // TIDE RAPTOR — "Institutional Pulse" spot-BTC-ETF premium signal
@@ -738,6 +773,25 @@ pub const LLM_OLLAMA_URL: &str = "http://localhost:11434";
 
 /// Default Ollama model.  Override with `OLLAMA_MODEL` env var.
 pub const LLM_OLLAMA_MODEL: &str = "llama3.2";
+
+/// LLM provider backend for the advisor: ollama | anthropic | openai |
+/// openai-compatible | chatgpt.  Default `ollama` preserves the historical
+/// behaviour (local/remote Ollama).  Override with the `LLM_PROVIDER` env var.
+pub const LLM_PROVIDER: &str = "ollama";
+
+/// Generic model name for the selected provider.  "" = use `LLM_OLLAMA_MODEL`
+/// for ollama, otherwise the provider's own default.  Override with `LLM_MODEL`.
+pub const LLM_MODEL: &str = "";
+
+/// Generic base-URL override (ollama / openai-compatible / optional openai or
+/// anthropic override).  "" = provider default (ollama falls back to
+/// `LLM_OLLAMA_URL`).  Override with `LLM_BASE_URL`.
+pub const LLM_BASE_URL: &str = "";
+
+/// Inference timeout (seconds) for CLOUD providers
+/// (anthropic / openai / openai-compatible / chatgpt).  Ollama keeps using
+/// `LLM_INFERENCE_TIMEOUT_SECS` because local CPU inference is much slower.
+pub const LLM_CLOUD_TIMEOUT_SECS: u64 = 120;
 
 
 // ============================================================================

--- a/src/helpers/balance.rs
+++ b/src/helpers/balance.rs
@@ -342,6 +342,7 @@ pub async fn reconcile_orphaned_positions(
                 pair_token_id: market.clone(),
                 fill_confirmed_at: Some(Utc::now()),
                 paired_leg_token_id: None, // fixed up below
+                ghost: false, // reconciled from a real on-chain balance
             });
 
             let source = if logged_strategy.is_some() { "DB" } else {
@@ -589,6 +590,7 @@ pub async fn arb_pair_fill_monitor(
                     pair_token_id: missing_market.clone(),
                     fill_confirmed_at: Some(Utc::now()),
                     paired_leg_token_id: Some(filled_market.clone()),
+                    ghost: ref_pos.ghost,
                 });
             }
         }
@@ -685,6 +687,7 @@ pub async fn arb_pair_fill_monitor(
                             pair_token_id: missing_market.clone(),
                             fill_confirmed_at: Some(Utc::now()),
                             paired_leg_token_id: Some(filled_market.clone()),
+                            ghost: ref_pos.ghost,
                         });
                     }
                     drop(map);
@@ -787,6 +790,7 @@ pub async fn arb_pair_fill_monitor(
                 filled_shares,
                 realized,
                 "Orphan flatten (bid exit)".to_string(),
+                false,
             ).await;
         }
         Err(e) => {

--- a/src/helpers/db.rs
+++ b/src/helpers/db.rs
@@ -146,7 +146,8 @@ async fn init_schema(pool: &SqlitePool) -> Result<()> {
             exit_price  TEXT    NOT NULL,
             shares      TEXT    NOT NULL,
             pnl         TEXT    NOT NULL,
-            reason      TEXT    NOT NULL
+            reason      TEXT    NOT NULL,
+            ghost_mode  INTEGER NOT NULL DEFAULT 0
         )"
     ).execute(pool).await?;
 
@@ -161,7 +162,8 @@ async fn init_schema(pool: &SqlitePool) -> Result<()> {
             side        TEXT    NOT NULL,
             entry_price TEXT    NOT NULL,
             shares      TEXT    NOT NULL,
-            session_id  TEXT    NOT NULL DEFAULT ''
+            session_id  TEXT    NOT NULL DEFAULT '',
+            ghost_mode  INTEGER NOT NULL DEFAULT 0
         )"
     ).execute(pool).await?;
 
@@ -520,6 +522,14 @@ async fn run_migrations(pool: &SqlitePool) {
     let _ = sqlx::query("ALTER TABLE entries ADD COLUMN session_id TEXT NOT NULL DEFAULT ''")
         .execute(pool).await;
 
+    // Add ghost_mode to trades and entries so simulated (paper) fills are
+    // distinguishable from live ones at the row level — mirrors the existing
+    // open_positions.ghost_mode column. DEFAULT 0 (live) for all pre-existing rows.
+    let _ = sqlx::query("ALTER TABLE trades ADD COLUMN ghost_mode INTEGER NOT NULL DEFAULT 0")
+        .execute(pool).await;
+    let _ = sqlx::query("ALTER TABLE entries ADD COLUMN ghost_mode INTEGER NOT NULL DEFAULT 0")
+        .execute(pool).await;
+
     // Index for fast session-scoped queries
     let _ = sqlx::query("CREATE INDEX IF NOT EXISTS idx_trades_session ON trades(session_id)")
         .execute(pool).await;
@@ -611,6 +621,7 @@ pub async fn close_session() {
 
 // ─── Trade / Entry writes ────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 pub async fn record_trade_db(
     pool: &SqlitePool,
     strategy: &str,
@@ -622,12 +633,13 @@ pub async fn record_trade_db(
     pnl: Decimal,
     reason: &str,
     timestamp: Option<DateTime<Utc>>,
+    ghost: bool,
 ) {
     let ts = timestamp.unwrap_or_else(|| Utc::now()).to_rfc3339();
     let sid = current_session_id();
     if let Err(e) = sqlx::query(
-        "INSERT INTO trades (ts, strategy, market, side, entry_price, exit_price, shares, pnl, reason, session_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO trades (ts, strategy, market, side, entry_price, exit_price, shares, pnl, reason, session_id, ghost_mode)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     .bind(&ts)
     .bind(strategy)
@@ -639,6 +651,7 @@ pub async fn record_trade_db(
     .bind(pnl.to_string())
     .bind(reason)
     .bind(sid)
+    .bind(ghost as i32)
     .execute(pool)
     .await {
         error!("❌ DB trade write failed: {}", e);
@@ -708,6 +721,7 @@ pub async fn record_settlement_trade_idempotent(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn record_entry_db(
     pool: &SqlitePool,
     strategy: &str,
@@ -716,12 +730,13 @@ pub async fn record_entry_db(
     side: &str,
     entry_price: Decimal,
     shares: Decimal,
+    ghost: bool,
 ) {
     let ts = Utc::now().to_rfc3339();
     let sid = current_session_id();
     if let Err(e) = sqlx::query(
-        "INSERT INTO entries (ts, strategy, token_id, market, side, entry_price, shares, session_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO entries (ts, strategy, token_id, market, side, entry_price, shares, session_id, ghost_mode)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     .bind(&ts)
     .bind(strategy)
@@ -731,6 +746,7 @@ pub async fn record_entry_db(
     .bind(entry_price.to_string())
     .bind(shares.to_string())
     .bind(sid)
+    .bind(ghost as i32)
     .execute(pool)
     .await {
         error!("❌ DB entry write failed: {}", e);
@@ -1199,6 +1215,8 @@ struct StaticConfigSnapshot<'a> {
     enable_llm_advisor:                bool,
     llm_advisor_interval_secs:         u64,
     llm_advisor_trades_lookback:       i64,
+    llm_provider:                      &'a str,
+    llm_model:                         &'a str,
     llm_ollama_url:                    &'a str,
     llm_ollama_model:                  &'a str,
 }
@@ -1273,6 +1291,8 @@ pub async fn record_static_config_snapshot(pool: &SqlitePool) {
         enable_llm_advisor:                config::ENABLE_LLM_ADVISOR,
         llm_advisor_interval_secs:         config::LLM_ADVISOR_INTERVAL_SECS,
         llm_advisor_trades_lookback:       config::LLM_ADVISOR_TRADES_LOOKBACK,
+        llm_provider:                      config::LLM_PROVIDER,
+        llm_model:                         config::LLM_MODEL,
         llm_ollama_url:                    config::LLM_OLLAMA_URL,
         llm_ollama_model:                  config::LLM_OLLAMA_MODEL,
     };
@@ -1439,8 +1459,8 @@ pub async fn purge_stale_open_positions(
     // by its phantom mark-to-market (observed: +$14.85 of redeemed ETH arb legs).
     const STALE_PENDING_GRACE_SECS: i64 = 3600; // 60 min ≫ indexer lag, ≪ orphan lifetime
 
-    let rows: Vec<(i64, String, Option<String>, String)> = match sqlx::query_as(
-        "SELECT id, token_id, status, ts FROM open_positions"
+    let rows: Vec<(i64, String, Option<String>, String, i64)> = match sqlx::query_as(
+        "SELECT id, token_id, status, ts, ghost_mode FROM open_positions"
     )
     .fetch_all(pool)
     .await {
@@ -1450,7 +1470,16 @@ pub async fn purge_stale_open_positions(
 
     let now = Utc::now();
     let mut purged = 0usize;
-    for (id, token_id, status, ts) in rows {
+    for (id, token_id, status, ts, ghost_mode) in rows {
+        // GHOST (paper) rows never exist on-chain, so the live-token set never contains
+        // them — chain-sync must NOT purge them (mirrors purge_all_live_open_positions,
+        // which deletes only ghost_mode = 0). They are closed explicitly by the ghost
+        // exit / orphan-close / expiry-settlement paths. Without this exemption every
+        // ghost open_positions row would vanish within one 300s cleanup tick, defeating
+        // the paper-trading DB/UI parity goal.
+        if ghost_mode != 0 {
+            continue;
+        }
         // Still held on-chain (size > 0, not redeemable) — keep.
         if live_token_ids.contains(&token_id) {
             continue;
@@ -1631,6 +1660,8 @@ pub struct TradeRow {
     pub shares: String,
     pub pnl: String,
     pub reason: String,
+    /// True when this trade closed a simulated (paper/ghost) position.
+    pub ghost_mode: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -1719,7 +1750,7 @@ pub async fn recent_stop_loss_exists(
 /// Return the most recent `limit` completed trades, newest first.
 pub async fn get_recent_trades(pool: &SqlitePool, limit: i64) -> Vec<TradeRow> {
     match sqlx::query(
-        "SELECT ts, strategy, market, side, entry_price, exit_price, shares, pnl, reason
+        "SELECT ts, strategy, market, side, entry_price, exit_price, shares, pnl, reason, ghost_mode
          FROM trades ORDER BY ts DESC LIMIT ?"
     )
     .bind(limit)
@@ -1735,6 +1766,7 @@ pub async fn get_recent_trades(pool: &SqlitePool, limit: i64) -> Vec<TradeRow> {
             shares:      r.try_get::<String, _>(6).ok()?,
             pnl:         r.try_get::<String, _>(7).ok()?,
             reason:      r.try_get::<String, _>(8).ok()?,
+            ghost_mode:  r.try_get::<i64, _>(9).ok()? != 0,
         })).collect(),
         Err(e) => { error!("❌ DB get_recent_trades failed: {}", e); vec![] }
     }
@@ -1835,7 +1867,7 @@ pub async fn get_confirmed_positions(pool: &SqlitePool) -> Vec<OpenPositionRow> 
 pub async fn get_session_trades(pool: &SqlitePool) -> Vec<TradeRow> {
     let sid = current_session_id();
     match sqlx::query(
-        "SELECT ts, strategy, market, side, entry_price, exit_price, shares, pnl, reason
+        "SELECT ts, strategy, market, side, entry_price, exit_price, shares, pnl, reason, ghost_mode
          FROM trades WHERE session_id = ? ORDER BY ts DESC"
     )
     .bind(sid)
@@ -1851,6 +1883,7 @@ pub async fn get_session_trades(pool: &SqlitePool) -> Vec<TradeRow> {
             shares:      r.try_get::<String, _>(6).ok()?,
             pnl:         r.try_get::<String, _>(7).ok()?,
             reason:      r.try_get::<String, _>(8).ok()?,
+            ghost_mode:  r.try_get::<i64, _>(9).ok()? != 0,
         })).collect(),
         Err(e) => { error!("❌ DB get_session_trades failed: {}", e); vec![] }
     }
@@ -1866,7 +1899,7 @@ pub async fn get_session_trades(pool: &SqlitePool) -> Vec<TradeRow> {
 pub async fn get_previous_session_trades(pool: &SqlitePool, limit: i64) -> Vec<TradeRow> {
     let sid = current_session_id();
     match sqlx::query(
-        "SELECT ts, strategy, market, side, entry_price, exit_price, shares, pnl, reason
+        "SELECT ts, strategy, market, side, entry_price, exit_price, shares, pnl, reason, ghost_mode
          FROM trades
          WHERE (session_id IS NULL OR session_id != ?)
          ORDER BY ts DESC LIMIT ?"
@@ -1885,6 +1918,7 @@ pub async fn get_previous_session_trades(pool: &SqlitePool, limit: i64) -> Vec<T
             shares:      r.try_get::<String, _>(6).ok()?,
             pnl:         r.try_get::<String, _>(7).ok()?,
             reason:      r.try_get::<String, _>(8).ok()?,
+            ghost_mode:  r.try_get::<i64, _>(9).ok()? != 0,
         })).collect(),
         Err(e) => { error!("❌ DB get_previous_session_trades failed: {}", e); vec![] }
     }

--- a/src/helpers/llm_advisor.rs
+++ b/src/helpers/llm_advisor.rs
@@ -26,24 +26,27 @@
 ///
 /// ── Configuration ────────────────────────────────────────────────────────────
 ///   config.rs:       ENABLE_LLM_ADVISOR, LLM_ADVISOR_INTERVAL_SECS,
-///                    LLM_ADVISOR_TRADES_LOOKBACK, LLM_OLLAMA_URL, LLM_OLLAMA_MODEL
-///   env overrides:   OLLAMA_URL, OLLAMA_MODEL  (override the defaults above)
+///                    LLM_PROVIDER, LLM_MODEL, LLM_BASE_URL, LLM_CLOUD_TIMEOUT_SECS,
+///                    LLM_OLLAMA_URL, LLM_OLLAMA_MODEL
+///   env overrides:   LLM_PROVIDER, LLM_MODEL, LLM_BASE_URL, and provider keys
+///                    (ANTHROPIC_API_KEY / OPENAI_API_KEY / CHATGPT_ACCESS_TOKEN);
+///                    legacy OLLAMA_URL, OLLAMA_MODEL still honoured for ollama.
 ///   Telegram creds:  TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID  (same as rest of bot)
 ///
 /// ── Bring Your Own LLM ───────────────────────────────────────────────────────
-/// The advisor uses the Ollama /api/chat endpoint (OpenAI-compatible).
-/// Any model running in Ollama works.  Recommended: llama3.2, mistral, qwen2.5.
-/// Point OLLAMA_URL at a remote host for GPU-accelerated inference when running
-/// DRADIS on a headless cloud VPS.
+/// The provider is selected at runtime (see `helpers::llm_client`): `ollama`
+/// (default, local/remote — the historical behaviour), `anthropic`, `openai`,
+/// `openai-compatible` (vLLM / LM Studio / OpenRouter / Groq …) and `chatgpt`
+/// (OAuth subscription).  All provider-specific wiring lives in `llm_client.rs`;
+/// this loop only ever sees a `Box<dyn LlmChat>`.
 
-use reqwest::Client;
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{interval, Duration};
 use tracing::{error, info, warn};
 
 use crate::config;
+use crate::helpers::llm_client::{self, LlmChat};
 use crate::helpers::{db, dynamic_config::DynamicConfig, notifications};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -58,39 +61,10 @@ const LLM_ADVISOR_MIN_SESSION_TRADES: usize = 5;
 /// Kept low (5) to avoid prompt bloat — a 3b CPU model struggles past ~1500 input tokens.
 const LLM_ADVISOR_PRIOR_SESSION_SUPPLEMENT: i64 = 5;
 
-// ── Ollama API types ──────────────────────────────────────────────────────────
-
-#[derive(Serialize)]
-struct OllamaRequest {
-    model: String,
-    messages: Vec<OllamaMessage>,
-    stream: bool,
-    /// Optional generation parameters — keep output focused and concise.
-    options: OllamaOptions,
-}
-
-#[derive(Serialize)]
-struct OllamaOptions {
-    /// Allow fuller recommendations to be persisted to SQLite and shown in Control Tower.
-    /// Telegram truncation is handled separately after generation.
-    num_predict: u32,
-    temperature: f32,
-    /// Cap the KV-cache context window.  Smaller = faster prefill on CPU.
-    /// 3072 leaves room for the prompt plus a longer recommendation.
-    num_ctx: u32,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-struct OllamaMessage {
-    role: String,
-    content: String,
-}
-
-#[derive(Deserialize)]
-struct OllamaResponse {
-    message: OllamaMessage,
-    done_reason: Option<String>,
-}
+// ── LLM backend ───────────────────────────────────────────────────────────────
+// Provider selection, request/response wiring, timeouts and probing all live in
+// `helpers::llm_client` behind the `LlmChat` trait.  This module only builds the
+// prompts and drives the retry/notify loop.
 
 // ── System prompt ─────────────────────────────────────────────────────────────
 
@@ -404,65 +378,6 @@ fn build_user_prompt(
     lines.join("\n")
 }
 
-// ── Ollama API call ───────────────────────────────────────────────────────────
-
-/// Quick reachability probe: GET /api/tags with a short timeout.
-/// Returns Ok(()) if Ollama is up, Err otherwise.
-async fn probe_ollama(probe_client: &Client, ollama_base_url: &str) -> anyhow::Result<()> {
-    let url = format!("{}/api/tags", ollama_base_url.trim_end_matches('/'));
-    let resp = probe_client.get(&url).send().await?;
-    if resp.status().is_success() {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!("Ollama /api/tags returned HTTP {}", resp.status()))
-    }
-}
-
-async fn call_ollama(
-    client: &Client,
-    ollama_base_url: &str,
-    model: &str,
-    user_prompt: &str,
-) -> anyhow::Result<OllamaResponse> {
-    let url = format!("{}/api/chat", ollama_base_url.trim_end_matches('/'));
-
-    let request = OllamaRequest {
-        model: model.to_string(),
-        messages: vec![
-            OllamaMessage {
-                role: "system".to_string(),
-                content: system_prompt(),
-            },
-            OllamaMessage {
-                role: "user".to_string(),
-                content: user_prompt.to_string(),
-            },
-        ],
-        stream: false,
-        options: OllamaOptions {
-            num_predict: 900,
-            temperature: 0.3, // Low temperature: consistent, factual recommendations
-            num_ctx: 3072,     // Room for prompt + full recommendation without frequent length stops
-        },
-    };
-
-    let resp = client
-        .post(&url)
-        .json(&request)
-        .send()
-        .await?;
-
-    let status = resp.status();
-    if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
-        return Err(anyhow::anyhow!("Ollama HTTP {}: {}", status, body));
-    }
-
-    let mut ollama_resp: OllamaResponse = resp.json().await?;
-    ollama_resp.message.content = ollama_resp.message.content.trim().to_string();
-    Ok(ollama_resp)
-}
-
 // ── Main advisor loop ─────────────────────────────────────────────────────────
 
 /// Spawn this as a long-running tokio task at startup.
@@ -494,45 +409,36 @@ pub async fn run_llm_advisor_loop(
         return;
     }
 
-    // Resolve Ollama connection settings — env vars override compile-time defaults.
-    let ollama_url = std::env::var("OLLAMA_URL")
-        .unwrap_or_else(|_| config::LLM_OLLAMA_URL.to_string());
-    let ollama_model = std::env::var("OLLAMA_MODEL")
-        .unwrap_or_else(|_| config::LLM_OLLAMA_MODEL.to_string());
+    // Resolve provider + connection settings once at task start (NOT hot-reloaded).
+    // Legacy OLLAMA_URL/OLLAMA_MODEL are still honoured for the ollama provider.
+    let settings = match llm_client::LlmSettings::resolve_from_env() {
+        Ok(s) => s,
+        Err(e) => {
+            error!("🤖 LLM Advisor: configuration error, task exiting: {:#}", e);
+            return;
+        }
+    };
 
+    // Build the provider client.  All rig/HTTP wiring + timeout enforcement lives
+    // in `llm_client`; a build failure degrades (task exits) rather than panics.
+    let client: Box<dyn LlmChat> = match llm_client::build_client(&settings) {
+        Ok(c) => c,
+        Err(e) => {
+            error!("🤖 LLM Advisor: failed to build LLM client, task exiting: {:#}", e);
+            return;
+        }
+    };
+
+    // Startup log states provider + model + base URL.  API keys are NEVER logged.
     info!(
-        "🤖 LLM Advisor started (CAG multi-asset mode) — model: {} @ {} | interval: {}s | session: {}",
-        ollama_model,
-        ollama_url,
+        "🤖 LLM Advisor started (CAG multi-asset mode) — provider: {} | model: {} | base_url: {} | timeout: {}s | interval: {}s | session: {}",
+        settings.provider.as_str(),
+        settings.model,
+        settings.base_url_display(),
+        settings.timeout_secs,
         config::LLM_ADVISOR_INTERVAL_SECS,
         db::current_session_id(),
     );
-
-    // Two HTTP clients with different timeout profiles:
-    //
-    // probe_client — used for the pre-flight GET /api/tags health-check.
-    //   connect_timeout: 5 s  (fail fast if the container/host is unreachable)
-    //   timeout:        10 s  (total; /api/tags returns in <1 s when healthy)
-    //
-    // inference_client — used for the actual POST /api/chat.
-    //   connect_timeout: 10 s  (fast TCP failure; prevents silent hangs)
-    //   timeout:        480 s  (LLM_INFERENCE_TIMEOUT_SECS — measured on t3.large
-    //                           qwen2.5:3b takes ~360–400s; 480s gives a 20% buffer)
-    //
-    // Previously the timeout was 360s — exactly at the model's natural completion
-    // time — causing every first attempt to time out, triggering needless retry cycles
-    // that collectively consumed 12–17 min of a 30-min advisory interval.
-    let probe_client = Client::builder()
-        .connect_timeout(Duration::from_secs(5))
-        .timeout(Duration::from_secs(10))
-        .build()
-        .unwrap_or_default();
-
-    let http_client = Client::builder()
-        .connect_timeout(Duration::from_secs(10))
-        .timeout(Duration::from_secs(config::LLM_INFERENCE_TIMEOUT_SECS))
-        .build()
-        .unwrap_or_default();
 
     // Skip the first tick so we don't fire immediately at startup before any
     // trades have occurred.
@@ -633,13 +539,14 @@ pub async fn run_llm_advisor_loop(
         let total_trade_count = session_trade_count
             + prior_trades.as_ref().map(|p| p.len()).unwrap_or(0);
 
-        // ── Pre-flight: verify Ollama is reachable before a 6-min inference call ──
-        // Uses the fast probe_client (5 s connect / 10 s total).
-        // On failure we skip this cycle entirely rather than blocking the loop.
-        if let Err(e) = probe_ollama(&probe_client, &ollama_url).await {
+        // ── Pre-flight: verify the backend is reachable before a long inference ──
+        // For ollama this is a fast GET /api/tags (5 s connect / 10 s total);
+        // cloud providers skip probing (default Ok).  On failure we skip this
+        // cycle entirely rather than blocking the loop.
+        if let Err(e) = client.probe().await {
             warn!(
-                "🤖 LLM Advisor: Ollama unreachable at {} — skipping cycle ({})",
-                ollama_url, e
+                "🤖 LLM Advisor: backend unreachable ({} @ {}) — skipping cycle ({})",
+                settings.provider.as_str(), settings.base_url_display(), e
             );
             continue;
         }
@@ -658,7 +565,7 @@ pub async fn run_llm_advisor_loop(
 
         info!(
             "🤖 LLM Advisor: calling {} for session {} ({} session + {} prior trades, P&L ${:.2})...",
-            ollama_model,
+            client.model_tag(),
             &session_id[..16.min(session_id.len())],
             session_trade_count,
             total_trade_count - session_trade_count,
@@ -666,6 +573,8 @@ pub async fn run_llm_advisor_loop(
         );
 
         // Retry up to 2 times with a 30-second backoff on transient errors.
+        // (Per-request timeouts + any length-cap warning are handled inside the
+        // provider client; here we only orchestrate retries.)
         const MAX_RETRIES: u32 = 2;
         let mut last_err = String::new();
         let mut analysis_opt: Option<String> = None;
@@ -677,19 +586,13 @@ pub async fn run_llm_advisor_loop(
                 );
                 tokio::time::sleep(Duration::from_secs(30)).await;
             }
-            match call_ollama(&http_client, &ollama_url, &ollama_model, &user_prompt).await {
-                Ok(resp) => {
-                    if matches!(resp.done_reason.as_deref(), Some("length")) {
-                        warn!(
-                            "🤖 LLM Advisor: output hit Ollama length cap (num_predict={}) — consider increasing if recommendations still end mid-thought",
-                            900,
-                        );
-                    }
-                    analysis_opt = Some(resp.message.content);
+            match client.chat(&system_prompt(), &user_prompt).await {
+                Ok(analysis) => {
+                    analysis_opt = Some(analysis);
                     break;
                 }
                 Err(e) => {
-                    last_err = e.to_string();
+                    last_err = format!("{:#}", e);
                 }
             }
         }
@@ -703,7 +606,7 @@ pub async fn run_llm_advisor_loop(
                 // Write to primary pool (main CAG dashboard reads from there).
                 db::record_llm_recommendation(
                     &primary_pool,
-                    &ollama_model,
+                    &client.model_tag(),
                     total_trade_count as i64,
                     current_pnl,
                     &analysis,
@@ -728,8 +631,8 @@ pub async fn run_llm_advisor_loop(
             }
             None => {
                 error!(
-                    "🤖 LLM Advisor: Ollama call failed after {} retries ({}@{}): {}",
-                    MAX_RETRIES, ollama_model, ollama_url, last_err
+                    "🤖 LLM Advisor: LLM call failed after {} retries ({} @ {}): {}",
+                    MAX_RETRIES, client.model_tag(), settings.base_url_display(), last_err
                 );
             }
         }

--- a/src/helpers/llm_client.rs
+++ b/src/helpers/llm_client.rs
@@ -1,0 +1,755 @@
+//! Provider-neutral LLM chat client for the LLM Advisor.
+//!
+//! ── Why this module exists ────────────────────────────────────────────────────
+//! The advisor historically spoke raw Ollama HTTP.  This module generalises that
+//! into a small DRADIS-owned trait (`LlmChat`) with several backends:
+//!
+//!   • `ollama`             — local/remote Ollama (DEFAULT; behaviour preserved
+//!                            byte-for-byte via the hand-rolled reqwest client below)
+//!   • `anthropic`          — Claude models (ANTHROPIC_API_KEY)
+//!   • `openai`             — OpenAI platform (OPENAI_API_KEY, Chat Completions API)
+//!   • `openai-compatible`  — any OpenAI-shaped server (vLLM / LM Studio / OpenRouter /
+//!                            Groq …) via a custom base URL + optional key
+//!   • `chatgpt`            — "Sign in with ChatGPT" OAuth subscription backend
+//!
+//! ── Design rule ───────────────────────────────────────────────────────────────
+//! ALL `rig-core` usage is confined to THIS file.  rig's 0.x API churn therefore
+//! never leaks past the `LlmChat` trait — the advisor loop only ever sees
+//! `Box<dyn LlmChat>`.  The Ollama backend deliberately does NOT go through rig:
+//! rig's Ollama request body adds top-level `max_tokens` / `think` / duplicated
+//! `temperature` fields that differ from our historical wire format, so to keep an
+//! existing OLLAMA_URL/OLLAMA_MODEL deployment behaving IDENTICALLY we keep the
+//! original hand-rolled reqwest client (same endpoints, same
+//! num_ctx=3072 / num_predict=900 / temperature=0.3, same 5s/10s probe + 480s
+//! inference timeouts).
+//!
+//! Every backend additionally wraps its network call in `tokio::time::timeout`
+//! as defence-in-depth, regardless of any client-level timeout.
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio::time::timeout;
+use tracing::{error, warn};
+
+use rig_core::client::CompletionClient;
+use rig_core::completion::{AssistantContent, CompletionModel};
+use rig_core::providers::{anthropic, chatgpt, openai};
+
+use crate::config;
+
+// ── Trait ─────────────────────────────────────────────────────────────────────
+
+/// One-shot, non-streaming chat completion: system + user -> assistant text.
+///
+/// Implementors own their own timeout enforcement so the advisor loop can treat
+/// every provider uniformly.
+#[async_trait]
+pub trait LlmChat: Send + Sync {
+    /// Run a single system+user completion and return the assistant's plain text.
+    async fn chat(&self, system: &str, user: &str) -> Result<String>;
+
+    /// Human-readable "provider/model" tag, stored in `llm_recommendations.model`
+    /// and rendered as the Control Tower badge (e.g. "ollama/llama3.2",
+    /// "anthropic/claude-3-5-sonnet-latest").
+    fn model_tag(&self) -> String;
+
+    /// Cheap reachability pre-flight.  Cloud APIs skip this (default `Ok(())`);
+    /// Ollama overrides it with a `GET /api/tags` health check.
+    async fn probe(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+// ── Provider enum ─────────────────────────────────────────────────────────────
+
+/// Which LLM backend the advisor talks to.  Selected at runtime (no cargo feature).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LlmProvider {
+    Ollama,
+    Anthropic,
+    OpenAi,
+    OpenAiCompatible,
+    ChatGpt,
+}
+
+impl LlmProvider {
+    /// Canonical lowercase name, used as the first half of `model_tag`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LlmProvider::Ollama => "ollama",
+            LlmProvider::Anthropic => "anthropic",
+            LlmProvider::OpenAi => "openai",
+            LlmProvider::OpenAiCompatible => "openai-compatible",
+            LlmProvider::ChatGpt => "chatgpt",
+        }
+    }
+
+    /// Parse a provider name (case-insensitive, with a few aliases).
+    ///
+    /// An unrecognised value is NOT fatal: repo convention is degrade-don't-panic,
+    /// so we log an `error!` listing the valid values and fall back to Ollama.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> LlmProvider {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "ollama" => LlmProvider::Ollama,
+            "anthropic" => LlmProvider::Anthropic,
+            "openai" => LlmProvider::OpenAi,
+            "openai-compatible" | "openai_compatible" | "compat" => LlmProvider::OpenAiCompatible,
+            "chatgpt" | "chatgpt-oauth" | "openai-oauth" => LlmProvider::ChatGpt,
+            other => {
+                error!(
+                    "🤖 LLM Advisor: unknown LLM_PROVIDER '{}' — valid values: \
+                     ollama | anthropic | openai | openai-compatible | chatgpt. \
+                     Falling back to ollama.",
+                    other
+                );
+                LlmProvider::Ollama
+            }
+        }
+    }
+}
+
+// ── Settings + resolution ─────────────────────────────────────────────────────
+
+/// Fully-resolved connection settings for a single advisor run.
+///
+/// Resolution happens once at advisor start (NOT hot-reloaded), matching the
+/// historical behaviour of the Ollama env vars.
+pub struct LlmSettings {
+    pub provider: LlmProvider,
+    pub model: String,
+    /// ollama + openai-compatible (+ optional openai / anthropic / chatgpt override).
+    pub base_url: Option<String>,
+    /// API key / access token (never logged).
+    pub api_key: Option<String>,
+    pub temperature: f32,
+    pub max_tokens: u32,
+    pub timeout_secs: u64,
+}
+
+/// Trim to `None` when empty/whitespace so an empty env var or config const does
+/// NOT shadow a lower-priority source.
+fn non_empty(s: &str) -> Option<String> {
+    if s.trim().is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+/// Ollama base URL precedence (back-compat is a hard requirement):
+/// env `LLM_BASE_URL` → env `OLLAMA_URL` → config `LLM_BASE_URL` (if non-empty)
+/// → config `LLM_OLLAMA_URL`.
+fn resolve_ollama_base_url(
+    env_llm_base_url: Option<String>,
+    env_ollama_url: Option<String>,
+    cfg_llm_base_url: &str,
+    cfg_ollama_url: &str,
+) -> String {
+    env_llm_base_url
+        .or(env_ollama_url)
+        .or_else(|| non_empty(cfg_llm_base_url))
+        .unwrap_or_else(|| cfg_ollama_url.to_string())
+}
+
+/// Ollama model precedence:
+/// env `LLM_MODEL` → env `OLLAMA_MODEL` → config `LLM_MODEL` (if non-empty)
+/// → config `LLM_OLLAMA_MODEL`.
+fn resolve_ollama_model(
+    env_llm_model: Option<String>,
+    env_ollama_model: Option<String>,
+    cfg_llm_model: &str,
+    cfg_ollama_model: &str,
+) -> String {
+    env_llm_model
+        .or(env_ollama_model)
+        .or_else(|| non_empty(cfg_llm_model))
+        .unwrap_or_else(|| cfg_ollama_model.to_string())
+}
+
+/// Non-ollama model precedence: env `LLM_MODEL` → config `LLM_MODEL` (if non-empty).
+/// `None` here is a hard error (cloud providers have no sensible local default).
+fn resolve_cloud_model(env_llm_model: Option<String>, cfg_llm_model: &str) -> Option<String> {
+    env_llm_model.or_else(|| non_empty(cfg_llm_model))
+}
+
+impl LlmSettings {
+    /// Resolve the advisor's LLM settings from env vars + compile-time config.
+    ///
+    /// Reads (once): `LLM_PROVIDER`, `LLM_MODEL`, `LLM_BASE_URL`, legacy
+    /// `OLLAMA_URL` / `OLLAMA_MODEL`, and per-provider keys (`ANTHROPIC_API_KEY`,
+    /// `OPENAI_API_KEY`, `CHATGPT_ACCESS_TOKEN`).
+    pub fn resolve_from_env() -> Result<LlmSettings> {
+        let env_opt =
+            |k: &str| std::env::var(k).ok().filter(|v| !v.trim().is_empty());
+
+        let provider = match env_opt("LLM_PROVIDER") {
+            Some(v) => LlmProvider::from_str(&v),
+            None => LlmProvider::from_str(config::LLM_PROVIDER),
+        };
+
+        match provider {
+            LlmProvider::Ollama => {
+                let base_url = resolve_ollama_base_url(
+                    env_opt("LLM_BASE_URL"),
+                    env_opt("OLLAMA_URL"),
+                    config::LLM_BASE_URL,
+                    config::LLM_OLLAMA_URL,
+                );
+                let model = resolve_ollama_model(
+                    env_opt("LLM_MODEL"),
+                    env_opt("OLLAMA_MODEL"),
+                    config::LLM_MODEL,
+                    config::LLM_OLLAMA_MODEL,
+                );
+                Ok(LlmSettings {
+                    provider,
+                    model,
+                    base_url: Some(base_url),
+                    api_key: None,
+                    temperature: 0.3,
+                    max_tokens: 900,
+                    timeout_secs: config::LLM_INFERENCE_TIMEOUT_SECS,
+                })
+            }
+            _ => {
+                let model = resolve_cloud_model(env_opt("LLM_MODEL"), config::LLM_MODEL)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "provider '{}' requires a model name — set LLM_MODEL (env) \
+                             or config::LLM_MODEL",
+                            provider.as_str()
+                        )
+                    })?;
+
+                let base_url = env_opt("LLM_BASE_URL").or_else(|| non_empty(config::LLM_BASE_URL));
+
+                let api_key = match provider {
+                    LlmProvider::Anthropic => env_opt("ANTHROPIC_API_KEY"),
+                    LlmProvider::OpenAi | LlmProvider::OpenAiCompatible => env_opt("OPENAI_API_KEY"),
+                    LlmProvider::ChatGpt => env_opt("CHATGPT_ACCESS_TOKEN"),
+                    LlmProvider::Ollama => unreachable!(),
+                };
+
+                Ok(LlmSettings {
+                    provider,
+                    model,
+                    base_url,
+                    api_key,
+                    temperature: 0.3,
+                    max_tokens: 900,
+                    timeout_secs: config::LLM_CLOUD_TIMEOUT_SECS,
+                })
+            }
+        }
+    }
+
+    /// A display string for logs — base URL or a "(provider default)" placeholder.
+    /// NEVER contains the API key.
+    pub fn base_url_display(&self) -> String {
+        self.base_url
+            .clone()
+            .unwrap_or_else(|| "(provider default)".to_string())
+    }
+}
+
+// ── Constructor ───────────────────────────────────────────────────────────────
+
+/// Build a boxed `LlmChat` client for the resolved settings.
+///
+/// Returns `Err` (degrade-don't-panic) if a required input is missing; the
+/// advisor logs it and exits its task rather than crashing the process.
+pub fn build_client(settings: &LlmSettings) -> Result<Box<dyn LlmChat>> {
+    let tag = format!("{}/{}", settings.provider.as_str(), settings.model);
+
+    match settings.provider {
+        LlmProvider::Ollama => {
+            let base = settings
+                .base_url
+                .clone()
+                .unwrap_or_else(|| config::LLM_OLLAMA_URL.to_string());
+            let client = OllamaClient::new(base, settings.model.clone(), settings.timeout_secs, tag)?;
+            Ok(Box::new(client))
+        }
+        LlmProvider::Anthropic => {
+            let key = settings
+                .api_key
+                .clone()
+                .ok_or_else(|| anyhow!("anthropic provider requires ANTHROPIC_API_KEY"))?;
+            let mut builder = anthropic::Client::builder().api_key(key);
+            if let Some(base) = &settings.base_url {
+                builder = builder.base_url(base);
+            }
+            let client = builder
+                .build()
+                .map_err(|e| anyhow!("failed to build anthropic client: {e}"))?;
+            let model = client.completion_model(&settings.model);
+            Ok(Box::new(RigChatClient::new(model, tag, settings)))
+        }
+        LlmProvider::OpenAi => {
+            let key = settings
+                .api_key
+                .clone()
+                .ok_or_else(|| anyhow!("openai provider requires OPENAI_API_KEY"))?;
+            // Chat Completions API (not the Responses API) — the widely-supported shape.
+            let mut builder = openai::CompletionsClient::builder().api_key(key);
+            if let Some(base) = &settings.base_url {
+                builder = builder.base_url(base);
+            }
+            let client = builder
+                .build()
+                .map_err(|e| anyhow!("failed to build openai client: {e}"))?;
+            let model = client.completion_model(&settings.model);
+            Ok(Box::new(RigChatClient::new(model, tag, settings)))
+        }
+        LlmProvider::OpenAiCompatible => {
+            let base = settings.base_url.clone().ok_or_else(|| {
+                anyhow!(
+                    "openai-compatible provider requires a base URL — set LLM_BASE_URL \
+                     (e.g. http://localhost:1234/v1)"
+                )
+            })?;
+            // Many local servers need no key; rig still requires one, so use a dummy.
+            let key = settings
+                .api_key
+                .clone()
+                .unwrap_or_else(|| "not-needed".to_string());
+            let client = openai::CompletionsClient::builder()
+                .api_key(key)
+                .base_url(&base)
+                .build()
+                .map_err(|e| anyhow!("failed to build openai-compatible client: {e}"))?;
+            let model = client.completion_model(&settings.model);
+            Ok(Box::new(RigChatClient::new(model, tag, settings)))
+        }
+        LlmProvider::ChatGpt => {
+            // OAuth "Sign in with ChatGPT" subscription backend.
+            //   • CHATGPT_ACCESS_TOKEN set  → explicit access-token auth
+            //   • otherwise                 → OAuth (reads/refreshes rig's auth.json;
+            //                                 default ~/.config/chatgpt/auth.json, or
+            //                                 point CHATGPT_AUTH_FILE at another file)
+            let account_id = std::env::var("CHATGPT_ACCOUNT_ID")
+                .ok()
+                .filter(|v| !v.trim().is_empty());
+            let auth_file = std::env::var("CHATGPT_AUTH_FILE")
+                .ok()
+                .filter(|v| !v.trim().is_empty());
+
+            let mut builder = chatgpt::Client::builder();
+            if let Some(base) = &settings.base_url {
+                builder = builder.base_url(base);
+            }
+
+            let keyed = match &settings.api_key {
+                Some(token) => builder.api_key(chatgpt::ChatGPTAuth::AccessToken {
+                    access_token: token.clone(),
+                    account_id,
+                }),
+                None => builder.oauth(),
+            };
+            let keyed = match auth_file {
+                Some(path) => keyed.auth_file(path),
+                None => keyed,
+            };
+            let client = keyed
+                .build()
+                .map_err(|e| anyhow!("failed to build chatgpt client: {e}"))?;
+            let model = client.completion_model(&settings.model);
+            Ok(Box::new(RigChatClient::new(model, tag, settings)))
+        }
+    }
+}
+
+// ── rig-backed cloud client ───────────────────────────────────────────────────
+
+/// Generic adapter that drives ANY rig `CompletionModel` (anthropic / openai /
+/// openai-compatible / chatgpt) through the `LlmChat` trait.
+struct RigChatClient<M: CompletionModel> {
+    model: M,
+    tag: String,
+    temperature: f64,
+    max_tokens: u64,
+    timeout_secs: u64,
+}
+
+impl<M: CompletionModel> RigChatClient<M> {
+    fn new(model: M, tag: String, settings: &LlmSettings) -> Self {
+        Self {
+            model,
+            tag,
+            temperature: settings.temperature as f64,
+            max_tokens: settings.max_tokens as u64,
+            timeout_secs: settings.timeout_secs,
+        }
+    }
+}
+
+#[async_trait]
+impl<M> LlmChat for RigChatClient<M>
+where
+    M: CompletionModel + Send + Sync + 'static,
+{
+    async fn chat(&self, system: &str, user: &str) -> Result<String> {
+        // preamble = system prompt, prompt/last message = user prompt.
+        // (temperature / max_tokens are best-effort: some providers, e.g. the
+        // chatgpt backend, intentionally ignore them.)
+        let fut = self
+            .model
+            .completion_request(user.to_string())
+            .preamble(system.to_string())
+            .temperature(self.temperature)
+            .max_tokens(self.max_tokens)
+            .send();
+
+        let resp = timeout(Duration::from_secs(self.timeout_secs), fut)
+            .await
+            .with_context(|| format!("LLM request timed out after {}s", self.timeout_secs))?
+            .context("LLM completion request failed")?;
+
+        // Extract plain text from the assistant choice (ignore tool/reasoning parts).
+        let mut text = String::new();
+        for content in resp.choice.iter() {
+            if let AssistantContent::Text(t) = content {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(&t.text);
+            }
+        }
+        let text = text.trim().to_string();
+        if text.is_empty() {
+            return Err(anyhow!("LLM returned no text content"));
+        }
+        Ok(text)
+    }
+
+    fn model_tag(&self) -> String {
+        self.tag.clone()
+    }
+}
+
+// ── Ollama backend (hand-rolled reqwest — behaviour preserved) ─────────────────
+
+#[derive(Serialize)]
+struct OllamaRequest {
+    model: String,
+    messages: Vec<OllamaMessage>,
+    stream: bool,
+    /// Optional generation parameters — keep output focused and concise.
+    options: OllamaOptions,
+}
+
+#[derive(Serialize)]
+struct OllamaOptions {
+    /// Allow fuller recommendations to be persisted to SQLite and shown in Control Tower.
+    /// Telegram truncation is handled separately after generation.
+    num_predict: u32,
+    temperature: f32,
+    /// Cap the KV-cache context window.  Smaller = faster prefill on CPU.
+    /// 3072 leaves room for the prompt plus a longer recommendation.
+    num_ctx: u32,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct OllamaMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct OllamaResponse {
+    message: OllamaMessage,
+    done_reason: Option<String>,
+}
+
+/// Hand-rolled Ollama backend that reproduces the historical wire format exactly:
+/// POST `{base}/api/chat` with `stream:false` and
+/// `options:{num_predict:900, temperature:0.3, num_ctx:3072}`; probe via
+/// GET `{base}/api/tags`.
+struct OllamaClient {
+    base_url: String,
+    model: String,
+    tag: String,
+    timeout_secs: u64,
+    /// Fast health-check client (5s connect / 10s total).
+    probe_client: reqwest::Client,
+    /// Inference client (10s connect / `timeout_secs` total).
+    http_client: reqwest::Client,
+}
+
+impl OllamaClient {
+    fn new(base_url: String, model: String, timeout_secs: u64, tag: String) -> Result<Self> {
+        let probe_client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("building ollama probe client")?;
+        let http_client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(timeout_secs))
+            .build()
+            .context("building ollama inference client")?;
+        Ok(Self {
+            base_url,
+            model,
+            tag,
+            timeout_secs,
+            probe_client,
+            http_client,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmChat for OllamaClient {
+    async fn chat(&self, system: &str, user: &str) -> Result<String> {
+        let url = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
+
+        let request = OllamaRequest {
+            model: self.model.clone(),
+            messages: vec![
+                OllamaMessage {
+                    role: "system".to_string(),
+                    content: system.to_string(),
+                },
+                OllamaMessage {
+                    role: "user".to_string(),
+                    content: user.to_string(),
+                },
+            ],
+            stream: false,
+            options: OllamaOptions {
+                num_predict: 900,
+                temperature: 0.3, // Low temperature: consistent, factual recommendations
+                num_ctx: 3072,    // Room for prompt + full recommendation without frequent length stops
+            },
+        };
+
+        let call = async {
+            let resp = self
+                .http_client
+                .post(&url)
+                .json(&request)
+                .send()
+                .await
+                .context("ollama /api/chat request failed")?;
+
+            let status = resp.status();
+            if !status.is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                return Err(anyhow!("Ollama HTTP {}: {}", status, body));
+            }
+
+            let ollama_resp: OllamaResponse =
+                resp.json().await.context("decoding ollama /api/chat response")?;
+            Ok::<OllamaResponse, anyhow::Error>(ollama_resp)
+        };
+
+        // Defence-in-depth timeout on top of the reqwest client-level timeout.
+        let resp = timeout(Duration::from_secs(self.timeout_secs), call)
+            .await
+            .with_context(|| format!("ollama request timed out after {}s", self.timeout_secs))??;
+
+        if matches!(resp.done_reason.as_deref(), Some("length")) {
+            warn!(
+                "🤖 LLM Advisor: output hit Ollama length cap (num_predict={}) — consider \
+                 increasing if recommendations still end mid-thought",
+                900,
+            );
+        }
+
+        let content = resp.message.content.trim().to_string();
+        if content.is_empty() {
+            return Err(anyhow!("Ollama returned empty content"));
+        }
+        Ok(content)
+    }
+
+    fn model_tag(&self) -> String {
+        self.tag.clone()
+    }
+
+    /// Quick reachability probe: GET /api/tags with a short timeout.
+    async fn probe(&self) -> Result<()> {
+        let url = format!("{}/api/tags", self.base_url.trim_end_matches('/'));
+        let resp = self
+            .probe_client
+            .get(&url)
+            .send()
+            .await
+            .context("ollama /api/tags probe failed")?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(anyhow!("Ollama /api/tags returned HTTP {}", resp.status()))
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_canonical_and_aliases() {
+        assert_eq!(LlmProvider::from_str("ollama"), LlmProvider::Ollama);
+        assert_eq!(LlmProvider::from_str("anthropic"), LlmProvider::Anthropic);
+        assert_eq!(LlmProvider::from_str("openai"), LlmProvider::OpenAi);
+        assert_eq!(
+            LlmProvider::from_str("openai-compatible"),
+            LlmProvider::OpenAiCompatible
+        );
+        assert_eq!(
+            LlmProvider::from_str("openai_compatible"),
+            LlmProvider::OpenAiCompatible
+        );
+        assert_eq!(LlmProvider::from_str("compat"), LlmProvider::OpenAiCompatible);
+        assert_eq!(LlmProvider::from_str("chatgpt"), LlmProvider::ChatGpt);
+        assert_eq!(LlmProvider::from_str("chatgpt-oauth"), LlmProvider::ChatGpt);
+        assert_eq!(LlmProvider::from_str("openai-oauth"), LlmProvider::ChatGpt);
+    }
+
+    #[test]
+    fn from_str_is_case_insensitive_and_trims() {
+        assert_eq!(LlmProvider::from_str("  Ollama  "), LlmProvider::Ollama);
+        assert_eq!(LlmProvider::from_str("ANTHROPIC"), LlmProvider::Anthropic);
+        assert_eq!(LlmProvider::from_str("OpenAI"), LlmProvider::OpenAi);
+        assert_eq!(LlmProvider::from_str("ChatGPT"), LlmProvider::ChatGpt);
+    }
+
+    #[test]
+    fn from_str_unknown_falls_back_to_ollama() {
+        // Unknown values degrade to Ollama (never panic).
+        assert_eq!(LlmProvider::from_str("gpt-9000"), LlmProvider::Ollama);
+        assert_eq!(LlmProvider::from_str(""), LlmProvider::Ollama);
+    }
+
+    #[test]
+    fn model_tag_format_is_provider_slash_model() {
+        assert_eq!(
+            format!("{}/{}", LlmProvider::Ollama.as_str(), "llama3.2"),
+            "ollama/llama3.2"
+        );
+        assert_eq!(
+            format!(
+                "{}/{}",
+                LlmProvider::Anthropic.as_str(),
+                "claude-3-5-sonnet-latest"
+            ),
+            "anthropic/claude-3-5-sonnet-latest"
+        );
+        assert_eq!(
+            format!("{}/{}", LlmProvider::OpenAiCompatible.as_str(), "qwen2.5"),
+            "openai-compatible/qwen2.5"
+        );
+    }
+
+    // ── Ollama back-compat resolution matrix ─────────────────────────────────
+    // Config defaults mirror the shipped values.
+    const CFG_OLLAMA_URL: &str = "http://localhost:11434";
+    const CFG_OLLAMA_MODEL: &str = "llama3.2";
+    // New generic consts default to empty ("" = fall back to the ollama consts).
+    const CFG_LLM_BASE_URL: &str = "";
+    const CFG_LLM_MODEL: &str = "";
+
+    fn s(v: &str) -> Option<String> {
+        Some(v.to_string())
+    }
+
+    #[test]
+    fn base_url_legacy_only_ollama_url() {
+        // Existing deployment: only OLLAMA_URL set → must be honoured verbatim.
+        let base = resolve_ollama_base_url(
+            None,
+            s("http://gpu-box:11434"),
+            CFG_LLM_BASE_URL,
+            CFG_OLLAMA_URL,
+        );
+        assert_eq!(base, "http://gpu-box:11434");
+    }
+
+    #[test]
+    fn base_url_nothing_set_uses_ollama_config_default() {
+        let base = resolve_ollama_base_url(None, None, CFG_LLM_BASE_URL, CFG_OLLAMA_URL);
+        assert_eq!(base, CFG_OLLAMA_URL);
+    }
+
+    #[test]
+    fn base_url_new_env_wins_over_legacy() {
+        let base = resolve_ollama_base_url(
+            s("http://new:1"),
+            s("http://legacy:2"),
+            CFG_LLM_BASE_URL,
+            CFG_OLLAMA_URL,
+        );
+        assert_eq!(base, "http://new:1");
+    }
+
+    #[test]
+    fn base_url_config_llm_base_url_beats_ollama_default() {
+        let base =
+            resolve_ollama_base_url(None, None, "http://cfg-generic:9", CFG_OLLAMA_URL);
+        assert_eq!(base, "http://cfg-generic:9");
+    }
+
+    #[test]
+    fn base_url_legacy_env_beats_config_llm_base_url() {
+        // env OLLAMA_URL outranks config::LLM_BASE_URL per the precedence table.
+        let base = resolve_ollama_base_url(
+            None,
+            s("http://legacy-env:2"),
+            "http://cfg-generic:9",
+            CFG_OLLAMA_URL,
+        );
+        assert_eq!(base, "http://legacy-env:2");
+    }
+
+    #[test]
+    fn model_legacy_only_ollama_model() {
+        let model =
+            resolve_ollama_model(None, s("mistral"), CFG_LLM_MODEL, CFG_OLLAMA_MODEL);
+        assert_eq!(model, "mistral");
+    }
+
+    #[test]
+    fn model_nothing_set_uses_ollama_config_default() {
+        let model = resolve_ollama_model(None, None, CFG_LLM_MODEL, CFG_OLLAMA_MODEL);
+        assert_eq!(model, CFG_OLLAMA_MODEL);
+    }
+
+    #[test]
+    fn model_new_env_wins_over_legacy() {
+        let model =
+            resolve_ollama_model(s("qwen2.5"), s("mistral"), CFG_LLM_MODEL, CFG_OLLAMA_MODEL);
+        assert_eq!(model, "qwen2.5");
+    }
+
+    #[test]
+    fn model_config_llm_model_beats_ollama_default() {
+        let model = resolve_ollama_model(None, None, "phi3", CFG_OLLAMA_MODEL);
+        assert_eq!(model, "phi3");
+    }
+
+    #[test]
+    fn cloud_model_requires_a_value() {
+        // No env, empty config → None (advisor turns this into a hard error).
+        assert_eq!(resolve_cloud_model(None, ""), None);
+        // env wins
+        assert_eq!(resolve_cloud_model(s("claude-x"), ""), s("claude-x"));
+        // config fallback
+        assert_eq!(resolve_cloud_model(None, "gpt-x"), s("gpt-x"));
+        // env beats config
+        assert_eq!(resolve_cloud_model(s("claude-x"), "gpt-x"), s("claude-x"));
+    }
+
+    #[test]
+    fn empty_strings_are_treated_as_unset() {
+        assert_eq!(non_empty(""), None);
+        assert_eq!(non_empty("   "), None);
+        assert_eq!(non_empty("x"), s("x"));
+    }
+}

--- a/src/helpers/metrics.rs
+++ b/src/helpers/metrics.rs
@@ -12,6 +12,7 @@ use crate::state::MarketSnapshot;
 /// Records a completed trade to the SQLite database.
 ///
 /// `asset` — lowercase crypto symbol, e.g. `"btc"`.  Drives the SQLite pool selection.
+#[allow(clippy::too_many_arguments)]
 pub async fn record_trade(
     asset: &str,
     strategy: String,
@@ -22,12 +23,14 @@ pub async fn record_trade(
     shares: Decimal,
     profit_usdc: Decimal,
     reason: String,
+    ghost: bool,
 ) {
-    record_trade_with_timestamp(asset, strategy, market, side, entry_price, exit_price, shares, profit_usdc, reason, None).await;
+    record_trade_with_timestamp(asset, strategy, market, side, entry_price, exit_price, shares, profit_usdc, reason, None, ghost).await;
 }
 
 /// Record a trade with an explicit timestamp (for retrospective settlements).
 /// If `timestamp` is None, uses current time.
+#[allow(clippy::too_many_arguments)]
 pub async fn record_trade_with_timestamp(
     asset: &str,
     strategy: String,
@@ -39,9 +42,10 @@ pub async fn record_trade_with_timestamp(
     profit_usdc: Decimal,
     reason: String,
     timestamp: Option<DateTime<Utc>>,
+    ghost: bool,
 ) {
     if let Some(pool) = db::pool_for(asset) {
-        db::record_trade_db(&pool, &strategy, &market, &side, entry_price, exit_price, shares, profit_usdc, &reason, timestamp).await;
+        db::record_trade_db(&pool, &strategy, &market, &side, entry_price, exit_price, shares, profit_usdc, &reason, timestamp, ghost).await;
         info!("📊 Trade recorded to database: {} {} {}", strategy, market, side);
     }
 }
@@ -50,6 +54,7 @@ pub async fn record_trade_with_timestamp(
 ///
 /// `asset` — lowercase crypto symbol, e.g. `"btc"`.  Drives SQLite pool selection.
 /// `token_id` — stored as decimal string representation (same as U256::to_string()).
+#[allow(clippy::too_many_arguments)]
 pub async fn record_entry(
     asset: &str,
     strategy: String,
@@ -58,9 +63,10 @@ pub async fn record_entry(
     side: String,
     entry_price: Decimal,
     shares: Decimal,
+    ghost: bool,
 ) {
     if let Some(pool) = db::pool_for(asset) {
-        db::record_entry_db(&pool, &strategy, &token_id, &market, &side, entry_price, shares).await;
+        db::record_entry_db(&pool, &strategy, &token_id, &market, &side, entry_price, shares, ghost).await;
     }
 }
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -11,9 +11,11 @@ pub mod orders;
 pub mod market;
 pub mod notifications;
 pub mod metrics;
+pub mod paper;
 pub mod config_helpers;
 pub mod db;
 pub mod dynamic_config;
+pub mod llm_client;
 pub mod llm_advisor;
 
 pub use price::*;

--- a/src/helpers/paper.rs
+++ b/src/helpers/paper.rs
@@ -1,0 +1,195 @@
+//! Pure math for the paper-trading (ghost) simulation.
+//!
+//! These helpers back the depth-aware simulated fills (D4), the resting-maker-quote
+//! fill heuristic (D5), and the binary expiry settlement payout (D6). They are kept
+//! free of any I/O or shared state so the fill/settlement logic can be unit-tested
+//! in isolation; the patrol loop and cleanup task supply the live inputs.
+
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+/// Weighted-average fill price for a simulated (ghost) taker BUY of `shares`.
+///
+/// Up to `depth` shares fill at `base_price` (the strategy's requested price with
+/// the usual entry offsets already applied); any excess fills one tranche worse, at
+/// `base_price + overflow_slippage`, capped at `price_cap`. The two tranches are
+/// weighted-averaged into a single effective entry price.
+///
+/// `depth <= 0` means no visible top-of-book liquidity, so the whole order fills in
+/// the overflow tranche. `shares <= 0` returns `base_price` (no fill to average).
+pub fn simulate_taker_buy_avg(
+    base_price: Decimal,
+    depth: Decimal,
+    shares: Decimal,
+    overflow_slippage: Decimal,
+    price_cap: Decimal,
+) -> Decimal {
+    if shares <= dec!(0) {
+        return base_price;
+    }
+    let at_base = shares.min(depth.max(dec!(0)));
+    let overflow = (shares - at_base).max(dec!(0));
+    let overflow_price = (base_price + overflow_slippage).min(price_cap);
+    (at_base * base_price + overflow * overflow_price) / shares
+}
+
+/// Weighted-average fill price for a simulated (ghost) taker SELL of `shares`.
+///
+/// Symmetric to [`simulate_taker_buy_avg`]: up to `depth` shares fill at `base_price`
+/// (the current bid with the usual exit offset already applied); any excess fills one
+/// tranche worse, at `base_price - overflow_slippage`, floored at `price_floor`.
+pub fn simulate_taker_sell_avg(
+    base_price: Decimal,
+    depth: Decimal,
+    shares: Decimal,
+    overflow_slippage: Decimal,
+    price_floor: Decimal,
+) -> Decimal {
+    if shares <= dec!(0) {
+        return base_price;
+    }
+    let at_base = shares.min(depth.max(dec!(0)));
+    let overflow = (shares - at_base).max(dec!(0));
+    let overflow_price = (base_price - overflow_slippage).max(price_floor);
+    (at_base * base_price + overflow * overflow_price) / shares
+}
+
+/// Advance the consecutive-tick counter for a resting ghost maker BUY quote.
+///
+/// A resting BUY at `quote_price` is "in the money to be hit" while the market's
+/// best bid has fallen to at or below it. Each such tick increments the counter;
+/// any tick where the best bid is above the quote resets it to zero.
+pub fn maker_next_tick_count(prev: u64, best_bid: Decimal, quote_price: Decimal) -> u64 {
+    if best_bid <= quote_price { prev + 1 } else { 0 }
+}
+
+/// Whether a resting ghost maker quote has rested long enough to be treated as filled.
+pub fn maker_should_fill(consecutive_ticks: u64, threshold: u64) -> bool {
+    consecutive_ticks >= threshold
+}
+
+/// Binary per-share settlement payout for a ghost position at expiry.
+///
+/// A YES token pays $1 when the oracle resolves at or above the strike (the "up"
+/// outcome), $0 otherwise; a NO token is the mirror. Matches the momentum/trend
+/// vipers' `oracle_price >= strike ⇒ YES` convention. When the strike is unknown
+/// the market cannot be resolved from the oracle, so the payout is $0.
+pub fn binary_settlement_payout(
+    is_yes_token: bool,
+    oracle_price: Decimal,
+    strike: Option<Decimal>,
+) -> Decimal {
+    match strike {
+        Some(k) => {
+            let yes_wins = oracle_price >= k;
+            let token_wins = if is_yes_token { yes_wins } else { !yes_wins };
+            if token_wins { dec!(1) } else { dec!(0) }
+        }
+        None => dec!(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SLIP: Decimal = dec!(0.02);
+    const CAP: Decimal = dec!(0.97);
+    const FLOOR: Decimal = dec!(0.01);
+
+    #[test]
+    fn buy_fully_within_depth_has_no_slippage() {
+        // 5 shares, 10 available at base → all fill at base, no overflow tranche.
+        let avg = simulate_taker_buy_avg(dec!(0.50), dec!(10), dec!(5), SLIP, CAP);
+        assert_eq!(avg, dec!(0.50));
+    }
+
+    #[test]
+    fn buy_overflow_is_weighted_averaged() {
+        // 10 shares, only 4 at base(0.50); 6 overflow at 0.52.
+        // avg = (4*0.50 + 6*0.52) / 10 = (2.00 + 3.12)/10 = 0.512
+        let avg = simulate_taker_buy_avg(dec!(0.50), dec!(4), dec!(10), SLIP, CAP);
+        assert_eq!(avg, dec!(0.512));
+    }
+
+    #[test]
+    fn buy_zero_depth_fills_entirely_in_overflow() {
+        let avg = simulate_taker_buy_avg(dec!(0.50), dec!(0), dec!(8), SLIP, CAP);
+        assert_eq!(avg, dec!(0.52));
+    }
+
+    #[test]
+    fn buy_overflow_price_respects_cap() {
+        // base 0.96 + 0.02 = 0.98 but capped at 0.97.
+        let avg = simulate_taker_buy_avg(dec!(0.96), dec!(0), dec!(1), SLIP, CAP);
+        assert_eq!(avg, dec!(0.97));
+    }
+
+    #[test]
+    fn sell_overflow_is_weighted_averaged() {
+        // 10 shares, 4 at base(0.50); 6 overflow at 0.48.
+        // avg = (4*0.50 + 6*0.48)/10 = (2.00 + 2.88)/10 = 0.488
+        let avg = simulate_taker_sell_avg(dec!(0.50), dec!(4), dec!(10), SLIP, FLOOR);
+        assert_eq!(avg, dec!(0.488));
+    }
+
+    #[test]
+    fn sell_overflow_price_respects_floor() {
+        // base 0.02 - 0.02 = 0.00 but floored at 0.01.
+        let avg = simulate_taker_sell_avg(dec!(0.02), dec!(0), dec!(1), SLIP, FLOOR);
+        assert_eq!(avg, dec!(0.01));
+    }
+
+    #[test]
+    fn zero_shares_returns_base() {
+        assert_eq!(simulate_taker_buy_avg(dec!(0.5), dec!(3), dec!(0), SLIP, CAP), dec!(0.5));
+        assert_eq!(simulate_taker_sell_avg(dec!(0.5), dec!(3), dec!(0), SLIP, FLOOR), dec!(0.5));
+    }
+
+    #[test]
+    fn maker_tick_counting_and_fill() {
+        let threshold = 3u64;
+        let quote = dec!(0.40);
+        // best bid above quote → resets.
+        let mut c = maker_next_tick_count(5, dec!(0.45), quote);
+        assert_eq!(c, 0);
+        assert!(!maker_should_fill(c, threshold));
+        // best bid <= quote for 3 consecutive ticks → fills.
+        c = maker_next_tick_count(c, dec!(0.40), quote); // 1
+        assert!(!maker_should_fill(c, threshold));
+        c = maker_next_tick_count(c, dec!(0.39), quote); // 2
+        assert!(!maker_should_fill(c, threshold));
+        c = maker_next_tick_count(c, dec!(0.38), quote); // 3
+        assert_eq!(c, 3);
+        assert!(maker_should_fill(c, threshold));
+    }
+
+    #[test]
+    fn settlement_payout_yes_wins_above_strike() {
+        let strike = Some(dec!(100000));
+        // Oracle above strike → YES pays $1, NO pays $0.
+        assert_eq!(binary_settlement_payout(true, dec!(100050), strike), dec!(1));
+        assert_eq!(binary_settlement_payout(false, dec!(100050), strike), dec!(0));
+    }
+
+    #[test]
+    fn settlement_payout_no_wins_below_strike() {
+        let strike = Some(dec!(100000));
+        // Oracle below strike → YES pays $0, NO pays $1.
+        assert_eq!(binary_settlement_payout(true, dec!(99950), strike), dec!(0));
+        assert_eq!(binary_settlement_payout(false, dec!(99950), strike), dec!(1));
+    }
+
+    #[test]
+    fn settlement_payout_exactly_at_strike_is_yes() {
+        let strike = Some(dec!(100000));
+        assert_eq!(binary_settlement_payout(true, dec!(100000), strike), dec!(1));
+        assert_eq!(binary_settlement_payout(false, dec!(100000), strike), dec!(0));
+    }
+
+    #[test]
+    fn settlement_payout_unknown_strike_is_zero() {
+        assert_eq!(binary_settlement_payout(true, dec!(100000), None), dec!(0));
+        assert_eq!(binary_settlement_payout(false, dec!(100000), None), dec!(0));
+    }
+}

--- a/src/helpers/time.rs
+++ b/src/helpers/time.rs
@@ -5,6 +5,8 @@ use regex::Regex;
 use std::str::FromStr as _;
 use tracing::debug;
 
+use crate::raptors::source::{self, MarketDataSource};
+
 /// Fetch strike price from Binance using market close time as reference
 pub async fn fetch_strike_price_from_close_time(
     http: &reqwest::Client,
@@ -32,27 +34,35 @@ pub async fn fetch_strike_price_from_close_time(
 
     let utc_millis = reference_time.timestamp_millis();
 
-    let binance_symbol = match filter {
-        "eth" => "ETHUSDT",
-        "sol" => "SOLUSDT",
-        _ => "BTCUSDT",
-    };
+    // Fetch the reference-minute close from the configured market-data source.
+    match MarketDataSource::resolve() {
+        MarketDataSource::Binance => {
+            let binance_symbol = source::binance_symbol(filter);
 
-    let url = format!("https://api.binance.com/api/v3/klines?symbol={}&interval=1m&startTime={}&limit=1", binance_symbol, utc_millis);
+            let url = format!("https://api.binance.com/api/v3/klines?symbol={}&interval=1m&startTime={}&limit=1", binance_symbol, utc_millis);
 
-    if let Ok(resp) = http.get(&url).send().await {
-        if let Ok(json) = resp.json::<serde_json::Value>().await {
-            if let Some(candle) = json.as_array().and_then(|a| a.first()) {
-                if let Some(close_str) = candle.as_array().and_then(|a| a.get(4)).and_then(|v| v.as_str()) {
-                    if let Ok(price) = Decimal::from_str(close_str) {
-                        debug!("✅ Fetched strike price from Binance at market close time: ${}", price);
-                        return Some(price);
+            if let Ok(resp) = http.get(&url).send().await {
+                if let Ok(json) = resp.json::<serde_json::Value>().await {
+                    if let Some(candle) = json.as_array().and_then(|a| a.first()) {
+                        if let Some(close_str) = candle.as_array().and_then(|a| a.get(4)).and_then(|v| v.as_str()) {
+                            if let Ok(price) = Decimal::from_str(close_str) {
+                                debug!("✅ Fetched strike price from Binance at market close time: ${}", price);
+                                return Some(price);
+                            }
+                        }
                     }
                 }
             }
+            None
+        }
+        MarketDataSource::Hyperliquid => {
+            if let Some(price) = fetch_hyperliquid_close(http, filter, utc_millis).await {
+                debug!("✅ Fetched strike price from Hyperliquid at market close time: ${}", price);
+                return Some(price);
+            }
+            None
         }
     }
-    None
 }
 
 /// Fetch historical strike price by parsing market description for date/time
@@ -106,24 +116,69 @@ pub async fn fetch_historical_strike_price(
     };
     let utc_millis = et_time.with_timezone(&Utc).timestamp_millis();
 
-    let binance_symbol = match filter {
-        "eth" => "ETHUSDT",
-        "sol" => "SOLUSDT",
-        _ => "BTCUSDT",
-    };
+    // Fetch the parsed-timestamp minute close from the configured source.
+    match MarketDataSource::resolve() {
+        MarketDataSource::Binance => {
+            let binance_symbol = source::binance_symbol(filter);
 
-    let url = format!("https://api.binance.com/api/v3/klines?symbol={}&interval=1m&startTime={}&limit=1", binance_symbol, utc_millis);
+            let url = format!("https://api.binance.com/api/v3/klines?symbol={}&interval=1m&startTime={}&limit=1", binance_symbol, utc_millis);
 
-    if let Ok(resp) = http.get(&url).send().await {
-        if let Ok(json) = resp.json::<serde_json::Value>().await {
-            if let Some(candle) = json.as_array().and_then(|a| a.first()) {
-                if let Some(close_str) = candle.as_array().and_then(|a| a.get(4)).and_then(|v| v.as_str()) {
-                    return Decimal::from_str(close_str).ok();
+            if let Ok(resp) = http.get(&url).send().await {
+                if let Ok(json) = resp.json::<serde_json::Value>().await {
+                    if let Some(candle) = json.as_array().and_then(|a| a.first()) {
+                        if let Some(close_str) = candle.as_array().and_then(|a| a.get(4)).and_then(|v| v.as_str()) {
+                            return Decimal::from_str(close_str).ok();
+                        }
+                    }
                 }
             }
+            None
         }
+        MarketDataSource::Hyperliquid => fetch_hyperliquid_close(http, filter, utc_millis).await,
     }
-    None
+}
+
+/// Fetch a 1-minute candle close from Hyperliquid via a plain reqwest POST to
+/// the public Info API (`candleSnapshot`). No SDK dependency — this path stays
+/// feature-flag-free so strike-price resolution compiles without the
+/// `hyperliquid` cargo feature. Returns `None` on any error (same graceful
+/// degradation as the Binance kline fetch).
+async fn fetch_hyperliquid_close(
+    http: &reqwest::Client,
+    filter: &str,
+    start_ms: i64,
+) -> Option<Decimal> {
+    let coin = source::hyperliquid_coin(filter);
+    // One 1-minute candle: [startTime, startTime + 60s).
+    let end_ms = start_ms + 60_000;
+    let body = serde_json::json!({
+        "type": "candleSnapshot",
+        "req": {
+            "coin": coin,
+            "interval": "1m",
+            "startTime": start_ms,
+            "endTime": end_ms,
+        }
+    });
+
+    let resp = http
+        .post("https://api.hyperliquid.xyz/info")
+        .json(&body)
+        .send()
+        .await
+        .ok()?;
+    let json = resp.json::<serde_json::Value>().await.ok()?;
+    parse_hyperliquid_candle_close(&json)
+}
+
+/// Parse the first candle's close (`c`) out of a Hyperliquid `candleSnapshot`
+/// response. The response is an array of candle objects `{t,T,s,i,o,h,l,c,v,n}`
+/// where every OHLCV value is a decimal string. Split out so it can be unit
+/// tested without a network round-trip.
+fn parse_hyperliquid_candle_close(json: &serde_json::Value) -> Option<Decimal> {
+    let candle = json.as_array().and_then(|a| a.first())?;
+    let close_str = candle.get("c").and_then(|v| v.as_str())?;
+    Decimal::from_str(close_str).ok()
 }
 
 /// Generate candidate market names for hourly crypto events
@@ -219,6 +274,43 @@ pub fn generate_daily_market_names(crypto_filter: &str, current_time_utc: DateTi
         names.push(format!("{} Up or Down on {} {}", crypto_name_short, month_name, day));
     }
     names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_hyperliquid_candle_close() {
+        // Shape mirrors a real candleSnapshot element (all values are strings).
+        let json = serde_json::json!([
+            {
+                "t": 1_700_000_000_000u64,
+                "T": 1_700_000_059_999u64,
+                "s": "BTC",
+                "i": "1m",
+                "o": "42010.0",
+                "h": "42100.5",
+                "l": "41990.0",
+                "c": "42055.5",
+                "v": "12.34",
+                "n": 87
+            }
+        ]);
+        assert_eq!(parse_hyperliquid_candle_close(&json), Some(Decimal::from_str("42055.5").unwrap()));
+    }
+
+    #[test]
+    fn empty_candle_array_returns_none() {
+        let json = serde_json::json!([]);
+        assert_eq!(parse_hyperliquid_candle_close(&json), None);
+    }
+
+    #[test]
+    fn missing_close_field_returns_none() {
+        let json = serde_json::json!([{ "t": 1u64, "o": "1.0" }]);
+        assert_eq!(parse_hyperliquid_candle_close(&json), None);
+    }
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,11 @@ pub mod raptors;
 pub mod squadron;
 pub mod cag;
 pub mod api;
+
+/// Historical-replay backtesting subsystem. Feature-gated (`backtest`) so default
+/// builds never pull rs-backtester's plotting/font stack. Replays real Hyperliquid
+/// candles + funding through the REAL viper `Strategy` objects behind the W1 clock
+/// seam, keeps an authoritative Decimal ledger with binary settlement, and reports
+/// via rs-backtester metrics + native CSV/JSON.
+#[cfg(feature = "backtest")]
+pub mod backtest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ use dradis::venues::intl::IntlClobVenue;
 use dradis::helpers::dynamic_config::DynamicConfig;
 use dradis::api::server::AssetRaptorHealth;
 #[cfg(feature = "intl_clob")]
+use dradis::raptors::source::MarketDataSource;
+#[cfg(feature = "intl_clob")]
 use tokio_util::sync::CancellationToken;
 
 use dradis::helpers::{
@@ -431,6 +433,12 @@ async fn main() -> Result<()> {
     // Store first asset's session for LLM Advisor (P&L tracking reference)
     let mut primary_session: Option<SessionState> = None;
 
+    // Resolve the market-data source ONCE (env MARKET_DATA_SOURCE → config →
+    // Binance). Logged a single time here; the per-asset spawn below branches on
+    // it. Default (unset) keeps the three Binance raptors byte-identical.
+    let market_data_source = MarketDataSource::resolve();
+    info!(" Market data source: {}", market_data_source.as_str());
+
     for asset in assets.iter() {
         // ── Per-asset raptor signal feeds ─────────────────────────────────────
         let (oracle_tx, oracle_rx)     = watch::channel(dec!(0));
@@ -440,18 +448,35 @@ async fn main() -> Result<()> {
         let (deriv_tx, deriv_rx)       =
             watch::channel(dradis::raptors::derivatives::DerivativesSnapshot::default());
 
-        tokio::spawn(dradis::raptors::price::run_price_raptor(
-            asset.clone(), oracle_tx, velocity_tx, drift_tx,
-            Arc::clone(&raptor_health_tx),
-        ));
-        tokio::spawn(dradis::raptors::funding::run_funding_raptor(
-            Arc::clone(&shared_http), asset.clone(), funding_tx,
-            Arc::clone(&raptor_health_tx),
-        ));
-        tokio::spawn(dradis::raptors::derivatives::run_derivatives_raptor(
-            Arc::clone(&shared_http), asset.clone(), deriv_tx,
-            Arc::clone(&raptor_health_tx),
-        ));
+        // ── Source-selected raptor spawn ──────────────────────────────────────
+        // Binance: three independent tasks (price WS + funding REST + OI/CVD
+        //          REST) — byte-identical to the pre-abstraction behavior.
+        // Hyperliquid: one WS task per asset feeding all five channels.
+        match market_data_source {
+            MarketDataSource::Binance => {
+                tokio::spawn(dradis::raptors::price::run_price_raptor(
+                    asset.clone(), oracle_tx, velocity_tx, drift_tx,
+                    Arc::clone(&raptor_health_tx),
+                ));
+                tokio::spawn(dradis::raptors::funding::run_funding_raptor(
+                    Arc::clone(&shared_http), asset.clone(), funding_tx,
+                    Arc::clone(&raptor_health_tx),
+                ));
+                tokio::spawn(dradis::raptors::derivatives::run_derivatives_raptor(
+                    Arc::clone(&shared_http), asset.clone(), deriv_tx,
+                    Arc::clone(&raptor_health_tx),
+                ));
+            }
+            #[cfg(feature = "hyperliquid")]
+            MarketDataSource::Hyperliquid => {
+                tokio::spawn(dradis::raptors::hyperliquid::run_hyperliquid_raptor(
+                    asset.clone(), oracle_tx, velocity_tx, drift_tx, funding_tx, deriv_tx,
+                    Arc::clone(&raptor_health_tx),
+                ));
+            }
+            #[cfg(not(feature = "hyperliquid"))]
+            MarketDataSource::Hyperliquid => unreachable!("resolve() falls back to Binance without the `hyperliquid` feature"),
+        }
 
         // Tide Raptor — "Institutional Pulse" from spot-BTC-ETF premium. BTC-only
         // and singular: spawned for the btc asset, reusing its live oracle feed.

--- a/src/orchestrator/strategy.rs
+++ b/src/orchestrator/strategy.rs
@@ -9,6 +9,7 @@ use rust_decimal::Decimal;
 use crate::state::{MarketConfig, MarketSnapshot, StrategySignal, StrategyStatus, PositionMap};
 use crate::helpers::dynamic_config::DynamicConfig;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::Mutex;
 
 /// Context passed to strategies containing all market data and shared state they need.
@@ -51,6 +52,35 @@ pub struct StrategyContext {
     /// the lock and refuse to open a second pair on the same market (hold-to-settle,
     /// no churn). `None` for venues/tests that don't supply it.
     pub arb_market_lockouts: Option<crate::state::ArbMarketLockouts>,
+    /// Clock seam — wall-clock "now" for this tick.
+    ///
+    /// In production this is `Utc::now()` captured at snapshot-build time, so every
+    /// viper gate reads a single consistent wall clock instead of calling
+    /// `Utc::now()` itself (behaviour-identical, captured microseconds earlier). The
+    /// backtest harness overrides it with the replayed HISTORICAL timestamp so
+    /// warmup/staleness/expiry/hold-time gates evaluate against the historical clock
+    /// at any replay speed. Vipers MUST read this instead of `chrono::Utc::now()`
+    /// inside `evaluate_entry`/`evaluate_exit`.
+    pub wall_now: DateTime<Utc>,
+    /// Clock seam — monotonic "now" for this tick.
+    ///
+    /// In production this is `std::time::Instant::now()` captured at snapshot-build
+    /// time; the backtest harness maps it onto a synthetic monotonic timeline
+    /// (`base + (t - t0)`) so per-viper cooldown timers (stored as `Instant`s)
+    /// measure historical elapsed time under replay. Vipers MUST read this instead
+    /// of `std::time::Instant::now()` inside their evaluate paths, and MUST stamp
+    /// cooldown state with it so the later comparison is consistent.
+    pub mono_now: Instant,
+    /// Replay-isolation flag — `false` in production (default), `true` only under the
+    /// backtest harness.
+    ///
+    /// When `true`, vipers MUST NOT consult the LIVE bot's persistent SQLite state
+    /// (e.g. TrendReversal's cross-restart cascade guard reads the live trades table).
+    /// An in-process replay run shares the process's DB pool registry, so an unguarded
+    /// lookup would leak the live stop-loss history into the simulation — read-only, but
+    /// a fidelity leak. Production behaviour with `false` is byte-identical to before this
+    /// flag existed.
+    pub is_replay: bool,
 }
 
 /// Trait that all strategies must implement.

--- a/src/raptors/derivatives.rs
+++ b/src/raptors/derivatives.rs
@@ -35,6 +35,7 @@ use tracing::{debug, warn};
 
 use crate::config;
 use crate::api::server::AssetRaptorHealth;
+use crate::raptors::source;
 
 /// Normalised derivatives-market snapshot broadcast to every consuming Viper.
 ///
@@ -59,11 +60,7 @@ pub async fn run_derivatives_raptor(
     deriv_tx: watch::Sender<DerivativesSnapshot>,
     raptor_health_tx: Arc<watch::Sender<HashMap<String, AssetRaptorHealth>>>,
 ) {
-    let symbol = match crypto_filter.as_str() {
-        "eth" => "ETHUSDT",
-        "sol" => "SOLUSDT",
-        _     => "BTCUSDT",
-    };
+    let symbol = source::binance_symbol(&crypto_filter);
     // Open interest — primary host + regional mirror fallback.
     let oi_primary  = format!("https://fapi.binance.com/fapi/v1/openInterest?symbol={}", symbol);
     let oi_fallback = format!("https://fapi.binance.us/fapi/v1/openInterest?symbol={}", symbol);

--- a/src/raptors/funding.rs
+++ b/src/raptors/funding.rs
@@ -23,6 +23,7 @@ use tracing::{debug, warn};
 
 use crate::config;
 use crate::api::server::AssetRaptorHealth;
+use crate::raptors::source;
 
 pub async fn run_funding_raptor(
     http: Arc<reqwest::Client>,
@@ -30,11 +31,7 @@ pub async fn run_funding_raptor(
     funding_tx: watch::Sender<Decimal>,
     raptor_health_tx: Arc<watch::Sender<HashMap<String, AssetRaptorHealth>>>,
 ) {
-    let symbol = match crypto_filter.as_str() {
-        "eth" => "ETHUSDT",
-        "sol" => "SOLUSDT",
-        _     => "BTCUSDT",
-    };
+    let symbol = source::binance_symbol(&crypto_filter);
     // Primary: Binance FAPI (futures). Fallback: Binance FAPI regional mirror.
     let url_primary  = format!("https://fapi.binance.com/fapi/v1/premiumIndex?symbol={}", symbol);
     let url_fallback = format!("https://fapi.binance.us/fapi/v1/premiumIndex?symbol={}", symbol);

--- a/src/raptors/hyperliquid.rs
+++ b/src/raptors/hyperliquid.rs
@@ -1,0 +1,350 @@
+//! Hyperliquid Raptor — one WebSocket task per asset, feeding EVERY raptor
+//! channel from a single Hyperliquid Info-API connection.
+//!
+//! Where the Binance source spawns three tasks (price WS + funding REST + OI/CVD
+//! REST), Hyperliquid multiplexes the same signals over one WS connection:
+//!
+//! │ HL subscription     │ Feeds                                                  │
+//! │─────────────────────│────────────────────────────────────────────────────────│
+//! │ `Trades{coin}`      │ oracle (last trade px), velocity/accel/drift, taker CVD │
+//! │ `ActiveAssetCtx{c}` │ funding rate (×8 normalized), open interest → OI delta  │
+//!
+//! The derived signals are byte-compatible with the Binance raptors — same
+//! `watch` channels, same `PriceKinematics` math, same `DerivativesSnapshot`
+//! shape — so `SquadronRaptors`, the vipers, and the telemetry surface need zero
+//! changes when `MARKET_DATA_SOURCE=hyperliquid`.
+//!
+//! Self-healing mirrors `price.rs`: a 30s recv timeout and an independent 60s
+//! "no parsed trade" zombie guard both force our own outer rebuild loop
+//! (drop the `InfoClient`, build a fresh one) with a 5s backoff. We do NOT rely
+//! on the SDK `WsManager`'s internal auto-reconnect for liveness — raptor
+//! self-healing must not depend on unverified SDK behaviour.
+
+use std::collections::{HashMap, VecDeque};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use hyperliquid_rust_sdk::{AssetCtx, BaseUrl, InfoClient, Message, Subscription};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use tokio::sync::{mpsc, watch};
+use tokio::time::{timeout as tokio_timeout, Duration, Instant};
+use tracing::{debug, info, warn};
+
+use crate::api::server::AssetRaptorHealth;
+use crate::config;
+use crate::raptors::derivatives::DerivativesSnapshot;
+use crate::raptors::kinematics::PriceKinematics;
+use crate::raptors::source;
+
+/// Rolling taker-volume window (5 minutes) used to derive the CVD ratio.
+const CVD_WINDOW_SECS: u64 = 300;
+
+/// One raptor task per asset. Feeds oracle/velocity/drift/funding/derivatives
+/// channels + the shared `AssetRaptorHealth` map, exactly as the trio of
+/// Binance raptors would for the same asset.
+pub async fn run_hyperliquid_raptor(
+    crypto_filter: String,
+    oracle_tx: watch::Sender<Decimal>,
+    velocity_tx: watch::Sender<(Decimal, Decimal, Decimal)>,
+    drift_tx: watch::Sender<(Decimal, Decimal)>,
+    funding_tx: watch::Sender<Decimal>,
+    deriv_tx: watch::Sender<DerivativesSnapshot>,
+    raptor_health_tx: Arc<watch::Sender<HashMap<String, AssetRaptorHealth>>>,
+) {
+    let coin = source::hyperliquid_coin(&crypto_filter);
+    let poll_interval = Duration::from_secs(config::DERIVATIVES_POLL_SECS);
+
+    // ── State that persists across reconnects ────────────────────────────────
+    // Momentum/drift accumulator — same math and reconnect semantics as price.rs.
+    let mut kin = PriceKinematics::new();
+    // Rolling 5m taker volume, split by aggressor side, for the CVD ratio.
+    let mut buy_vol: VecDeque<(Instant, Decimal)> = VecDeque::new();
+    let mut sell_vol: VecDeque<(Instant, Decimal)> = VecDeque::new();
+    // Last emitted CVD ratio. Seeded to 1.0 (neutral) to match Binance's
+    // `buySellRatio` semantics; preserved when the sell window is empty.
+    let mut cvd_ratio = dec!(1);
+    // Open-interest delta bookkeeping — sampled on the DERIVATIVES_POLL_SECS
+    // cadence so the 30s-delta semantics the vipers are tuned on are preserved,
+    // even though ActiveAssetCtx pushes far more frequently.
+    let mut prev_oi: Option<Decimal> = None;
+    let mut last_oi_sample: Option<Instant> = None;
+
+    loop {
+        // ── (Re)build the client + subscriptions ─────────────────────────────
+        let mut client = match InfoClient::new(None, Some(BaseUrl::Mainnet)).await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("⚠️ Hyperliquid Raptor: failed to build InfoClient for {}: {} — retrying in 5s", coin, e);
+                mark_offline(&raptor_health_tx, &crypto_filter);
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                continue;
+            }
+        };
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+        let sub_ok = client
+            .subscribe(Subscription::Trades { coin: coin.clone() }, tx.clone())
+            .await
+            .is_ok()
+            && client
+                .subscribe(Subscription::ActiveAssetCtx { coin: coin.clone() }, tx.clone())
+                .await
+                .is_ok();
+        // Our local senders are only needed to hand to the SDK; drop them so `rx`
+        // closes (→ recv returns None) once the WsManager drops its own senders.
+        drop(tx);
+
+        if !sub_ok {
+            warn!("⚠️ Hyperliquid Raptor: subscribe failed for {} — reconnecting in 5s", coin);
+            mark_offline(&raptor_health_tx, &crypto_filter);
+            drop(client);
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            continue;
+        }
+
+        info!(" Hyperliquid Raptor connected for {} ({})", coin, crypto_filter.to_uppercase());
+
+        // `last_trade` tracks the last time we parsed an actual trade. ctx frames
+        // keep arriving and reset the 30s recv timeout, so — like price.rs — we
+        // need an independent 60s guard to catch a "zombie" feed where ctx is
+        // alive but the trade stream has silently stopped.
+        let mut last_trade = Instant::now();
+        // `last_ctx` is the mirror guard for the assetCtx stream: trades alone
+        // keep the socket "alive", so a stalled ctx subscription would silently
+        // freeze funding/OI/CVD at their last values (Binance can't do this —
+        // its funding/derivatives pollers fail loudly on their own). ctx pushes
+        // ~1/s, so 90s means dozens of missed frames.
+        let mut last_ctx = Instant::now();
+        // Kinematics are sampled at ~1 Hz with the latest trade price, matching
+        // the Binance @ticker cadence price.rs sees. Feeding every raw trade
+        // (dozens/s) would collapse `acceleration` — a per-sample derivative —
+        // into inter-trade bid/ask-bounce noise and neuter the Momentum viper's
+        // accel gate. ctx frames (~1/s) keep the sampler ticking through trade
+        // gaps so velocity decays exactly like it does on Binance's always-on
+        // ticker.
+        let mut latest_px: Option<Decimal> = None;
+        let mut last_kin_feed: Option<Instant> = None;
+
+        'ws: loop {
+            // Zombie guard: no parsed trade in 60s → force reconnect.
+            if last_trade.elapsed() >= Duration::from_secs(60) {
+                warn!("⚠️ Hyperliquid Raptor {}: no trade in 60s (zombie WS — ctx alive but trades silent) — reconnecting", coin);
+                break 'ws;
+            }
+            // Ctx staleness guard: no assetCtx frame in 90s → funding/OI would
+            // go stale while trades keep flowing; force reconnect instead.
+            if last_ctx.elapsed() >= Duration::from_secs(90) {
+                warn!("⚠️ Hyperliquid Raptor {}: no assetCtx in 90s (funding/OI stale) — reconnecting", coin);
+                break 'ws;
+            }
+            // 1 Hz kinematics feed from the latest trade price (see note above).
+            if let Some(px) = latest_px {
+                if last_kin_feed.is_none_or(|t| t.elapsed() >= Duration::from_secs(1)) {
+                    let now = Instant::now();
+                    last_kin_feed = Some(now);
+                    let sig = kin.on_price(now, px);
+                    let _ = velocity_tx.send((sig.velocity_5s, sig.velocity_1s, sig.acceleration));
+                    let _ = drift_tx.send((sig.drift_60m, sig.drift_10m));
+                    raptor_health_tx.send_modify(|map| {
+                        let h = map.entry(crypto_filter.clone()).or_default();
+                        h.velocity_5s = sig.velocity_5s;
+                        h.velocity_1s = sig.velocity_1s;
+                        h.acceleration = sig.acceleration;
+                        h.drift_60m = sig.drift_60m;
+                        h.drift_10m = sig.drift_10m;
+                    });
+                }
+            }
+
+            match tokio_timeout(Duration::from_secs(30), rx.recv()).await {
+                Ok(Some(msg)) => match msg {
+                    Message::Trades(trades) => {
+                        for trade in trades.data {
+                            let (Ok(px), Ok(sz)) = (
+                                Decimal::from_str(&trade.px),
+                                Decimal::from_str(&trade.sz),
+                            ) else {
+                                continue;
+                            };
+                            let now = Instant::now();
+                            last_trade = now;
+
+                            // Oracle = last trade price (absolute value, safe to
+                            // refresh per trade). Velocity/accel/drift are fed at
+                            // 1 Hz by the loop-top sampler, NOT per trade.
+                            latest_px = Some(px);
+                            let _ = oracle_tx.send(px);
+
+                            // Taker CVD: HL trade `side` is the aggressor side —
+                            // "B" = buy (lifted the ask), "A" = sell (hit the bid).
+                            match trade.side.as_str() {
+                                "B" => buy_vol.push_back((now, sz)),
+                                "A" => sell_vol.push_back((now, sz)),
+                                _ => {}
+                            }
+                            trim_window(&mut buy_vol, now);
+                            trim_window(&mut sell_vol, now);
+
+                            raptor_health_tx.send_modify(|map| {
+                                let h = map.entry(crypto_filter.clone()).or_default();
+                                h.price_connected = true;
+                                h.oracle_price = px;
+                            });
+                        }
+                    }
+                    Message::ActiveAssetCtx(actx) => {
+                        last_ctx = Instant::now();
+                        // Only perp contexts carry funding + open interest.
+                        if let AssetCtx::Perps(perp) = actx.data.ctx {
+                            // Funding normalization: Hyperliquid quotes an HOURLY
+                            // funding rate, whereas Binance `lastFundingRate` is
+                            // per-8h. The BASIS_*_FUNDING_THRESHOLD viper gates were
+                            // tuned on 8h rates, so emit HL funding × 8 to preserve
+                            // their meaning across sources.
+                            if let Ok(hourly) = Decimal::from_str(&perp.funding) {
+                                let normalized = normalize_funding_8h(hourly);
+                                let _ = funding_tx.send(normalized);
+                                raptor_health_tx.send_modify(|map| {
+                                    let h = map.entry(crypto_filter.clone()).or_default();
+                                    h.funding_connected = true;
+                                    h.funding_rate = normalized;
+                                });
+                                debug!("📡 Hyperliquid funding {}: {:.6}% (×8 of hourly)", coin, normalized * dec!(100));
+                            }
+
+                            // Open interest → sampled OI delta on the poll cadence.
+                            if let Ok(open_interest) = Decimal::from_str(&perp.open_interest) {
+                                let now = Instant::now();
+                                let due = last_oi_sample.is_none_or(|t| t.elapsed() >= poll_interval);
+                                if due {
+                                    let oi_delta_pct = match prev_oi {
+                                        Some(p) if p > dec!(0) => (open_interest - p) / p,
+                                        _ => dec!(0),
+                                    };
+                                    prev_oi = Some(open_interest);
+                                    last_oi_sample = Some(now);
+
+                                    // Recompute CVD ratio from the rolling windows.
+                                    // Zero sell volume → keep the previous ratio.
+                                    let buy_sum: Decimal = buy_vol.iter().map(|(_, v)| *v).sum();
+                                    let sell_sum: Decimal = sell_vol.iter().map(|(_, v)| *v).sum();
+                                    cvd_ratio = cvd_ratio_or_prev(buy_sum, sell_sum, cvd_ratio);
+
+                                    let snap = DerivativesSnapshot { open_interest, oi_delta_pct, cvd_ratio };
+                                    let _ = deriv_tx.send(snap);
+                                    raptor_health_tx.send_modify(|map| {
+                                        let h = map.entry(crypto_filter.clone()).or_default();
+                                        h.deriv_connected = true;
+                                        h.open_interest = open_interest;
+                                        h.oi_delta_pct = oi_delta_pct;
+                                        h.cvd_ratio = cvd_ratio;
+                                    });
+                                    debug!(
+                                        "📡 Hyperliquid derivatives {}: OI={} ΔOI={:.3}% CVD={:.3}",
+                                        coin, open_interest, oi_delta_pct * dec!(100), cvd_ratio,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    // WsManager pushes NoData when the socket drops — treat as a
+                    // disconnect and rebuild via our own outer loop.
+                    Message::NoData => {
+                        warn!("⚠️ Hyperliquid Raptor {}: WS closed by server — reconnecting", coin);
+                        break 'ws;
+                    }
+                    Message::HyperliquidError(err) => {
+                        warn!("⚠️ Hyperliquid Raptor {}: server error: {}", coin, err);
+                    }
+                    // Pong / SubscriptionResponse / other channels — ignore.
+                    _ => {}
+                },
+                // All senders dropped → the WsManager reader stopped; reconnect.
+                Ok(None) => break 'ws,
+                // 30s with no message at all — silent stall; force reconnect.
+                Err(_) => {
+                    warn!("⚠️ Hyperliquid Raptor {}: no message in 30s — reconnecting", coin);
+                    break 'ws;
+                }
+            }
+        }
+
+        warn!("⚠️ Hyperliquid Raptor {} disconnected. Reconnecting in 5s...", coin);
+        mark_offline(&raptor_health_tx, &crypto_filter);
+        kin.reset_velocity();
+        drop(client);
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+/// Drop taker-volume entries older than the 5-minute CVD window.
+fn trim_window(window: &mut VecDeque<(Instant, Decimal)>, now: Instant) {
+    while let Some((t, _)) = window.front() {
+        if now.duration_since(*t).as_secs() >= CVD_WINDOW_SECS {
+            window.pop_front();
+        } else {
+            break;
+        }
+    }
+}
+
+/// Flip all three connection health flags to false for this asset while the
+/// single HL task is reconnecting (mirrors what the three Binance raptors do
+/// individually on disconnect).
+fn mark_offline(
+    raptor_health_tx: &Arc<watch::Sender<HashMap<String, AssetRaptorHealth>>>,
+    crypto_filter: &str,
+) {
+    raptor_health_tx.send_modify(|map| {
+        let h = map.entry(crypto_filter.to_string()).or_default();
+        h.price_connected = false;
+        h.funding_connected = false;
+        h.deriv_connected = false;
+    });
+}
+
+/// Normalize a Hyperliquid HOURLY funding rate onto Binance's per-8h scale so
+/// the `BASIS_*_FUNDING_THRESHOLD` viper gates (tuned on 8h `lastFundingRate`)
+/// keep their meaning: multiply by 8.
+fn normalize_funding_8h(hourly: Decimal) -> Decimal {
+    hourly * dec!(8)
+}
+
+/// Rolling taker CVD ratio = buy_vol / sell_vol over the window. When the sell
+/// window is empty (would divide by zero) keep the previous ratio, matching the
+/// "no fresh data → hold last" semantics of Binance's `buySellRatio`.
+fn cvd_ratio_or_prev(buy_sum: Decimal, sell_sum: Decimal, prev: Decimal) -> Decimal {
+    if sell_sum > dec!(0) {
+        buy_sum / sell_sum
+    } else {
+        prev
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn funding_normalized_hourly_to_8h() {
+        // A +0.00125%/hr rate becomes +0.01%/8h — the scale the viper thresholds expect.
+        assert_eq!(normalize_funding_8h(dec!(0.0000125)), dec!(0.0001));
+        assert_eq!(normalize_funding_8h(dec!(-0.0000125)), dec!(-0.0001));
+        assert_eq!(normalize_funding_8h(dec!(0)), dec!(0));
+    }
+
+    #[test]
+    fn cvd_ratio_basic_division() {
+        // 60 buy / 40 sell = 1.5 (buy-side aggression).
+        assert_eq!(cvd_ratio_or_prev(dec!(60), dec!(40), dec!(1)), dec!(1.5));
+    }
+
+    #[test]
+    fn cvd_ratio_zero_sell_keeps_previous() {
+        // No sell volume in the window → hold the previous ratio, never divide by 0.
+        assert_eq!(cvd_ratio_or_prev(dec!(25), dec!(0), dec!(1.2)), dec!(1.2));
+        // Initial neutral seed (1.0) is preserved before any sell volume arrives.
+        assert_eq!(cvd_ratio_or_prev(dec!(0), dec!(0), dec!(1)), dec!(1));
+    }
+}

--- a/src/raptors/kinematics.rs
+++ b/src/raptors/kinematics.rs
@@ -1,0 +1,253 @@
+//! Price kinematics — velocity / acceleration / drift math shared by every
+//! price-bearing raptor.
+//!
+//! This is the exact momentum/drift computation that used to live inline in
+//! `price.rs`, factored into a reusable struct so a second source (Hyperliquid
+//! trades) produces byte-identical `velocity_tx` / `drift_tx` signals from the
+//! same windows and history semantics.
+//!
+//! Semantics preserved verbatim from the original `run_price_raptor`:
+//!   • velocity_5s  — Δprice over the primary window (`MOMENTUM_WINDOW_SECS`, 5s)
+//!   • velocity_1s  — Δprice over the short window (`MOMENTUM_SHORT_WINDOW_SECS`, 1s);
+//!                    falls back to velocity_5s when no sub-1s history exists yet
+//!   • acceleration — Δ(velocity_5s) since the previous tick
+//!   • drift_60m    — Δprice over a full trailing hour (0 until ≥3600s of history)
+//!   • drift_10m    — Δprice over the trailing 10m window, active once ≥60s of
+//!                    history exists (fills the 5s–60m gap for GBoost feature [18])
+//!
+//! Reconnect semantics (`reset_velocity`) also mirror `price.rs`: on a WS
+//! reconnect the previous-velocity accumulator is zeroed and the 10-minute
+//! history is cleared, while the 5s and 60m histories are left to self-trim by
+//! elapsed time.
+
+use std::collections::VecDeque;
+
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use tokio::time::Instant;
+
+use crate::config;
+
+/// One tick's worth of derived momentum/drift signals.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Kinematics {
+    pub velocity_5s: Decimal,
+    pub velocity_1s: Decimal,
+    pub acceleration: Decimal,
+    pub drift_60m: Decimal,
+    pub drift_10m: Decimal,
+}
+
+/// Rolling price-history accumulator that derives momentum + drift signals.
+pub struct PriceKinematics {
+    /// Primary momentum window (`MOMENTUM_WINDOW_SECS`, 5s).
+    price_history: VecDeque<(Instant, Decimal)>,
+    /// 60-minute drift history.
+    price_history_60m: VecDeque<(Instant, Decimal)>,
+    /// 10-minute drift history.
+    price_history_10m: VecDeque<(Instant, Decimal)>,
+    /// Previous 5s velocity, for the acceleration derivative.
+    prev_velocity: Decimal,
+}
+
+impl PriceKinematics {
+    pub fn new() -> Self {
+        Self {
+            price_history: VecDeque::new(),
+            price_history_60m: VecDeque::new(),
+            price_history_10m: VecDeque::new(),
+            prev_velocity: dec!(0),
+        }
+    }
+
+    /// Feed one `(now, price)` tick and return the latest derived signals.
+    ///
+    /// The math here is a 1:1 port of the original inline block in `price.rs`;
+    /// changing it changes every downstream viper threshold, so it must not
+    /// drift.
+    pub fn on_price(&mut self, now: Instant, price: Decimal) -> Kinematics {
+        self.price_history.push_back((now, price));
+
+        // Trim entries older than the primary window (5s).
+        while let Some((t, _)) = self.price_history.front() {
+            if now.duration_since(*t).as_secs() >= config::MOMENTUM_WINDOW_SECS {
+                self.price_history.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        // Primary velocity (5s window).
+        let velocity_5s = if let Some((_, start_price)) = self.price_history.front() {
+            price - start_price
+        } else {
+            dec!(0)
+        };
+
+        // Short velocity (1s window).
+        let velocity_1s = {
+            let cutoff = config::MOMENTUM_SHORT_WINDOW_SECS;
+            let start_1s = self
+                .price_history
+                .iter()
+                .find(|(t, _)| now.duration_since(*t).as_secs() < cutoff);
+            match start_1s {
+                Some((_, p)) => price - p,
+                None => velocity_5s,
+            }
+        };
+
+        // Acceleration: rate of change of velocity.
+        let acceleration = velocity_5s - self.prev_velocity;
+        self.prev_velocity = velocity_5s;
+
+        // 60-minute drift.
+        self.price_history_60m.push_back((now, price));
+        while let Some((t, _)) = self.price_history_60m.front() {
+            if now.duration_since(*t).as_secs() > 3600 {
+                self.price_history_60m.pop_front();
+            } else {
+                break;
+            }
+        }
+        let drift_60m = if self.price_history_60m.len() > 1 {
+            if let Some((oldest_t, oldest_p)) = self.price_history_60m.front() {
+                if now.duration_since(*oldest_t).as_secs() >= 3600 {
+                    price - oldest_p
+                } else {
+                    dec!(0)
+                }
+            } else {
+                dec!(0)
+            }
+        } else {
+            dec!(0)
+        };
+
+        // 10-minute drift — fills the 5s–60m gap for GBoost feature [18].
+        // Active once at least 60s of history exists, per the original fix so the
+        // gate is live from the second minute rather than silent for 10 minutes.
+        self.price_history_10m.push_back((now, price));
+        while let Some((t, _)) = self.price_history_10m.front() {
+            if now.duration_since(*t).as_secs() > 600 {
+                self.price_history_10m.pop_front();
+            } else {
+                break;
+            }
+        }
+        let drift_10m = if let Some((oldest_t, oldest_p)) = self.price_history_10m.front() {
+            let window_secs = now.duration_since(*oldest_t).as_secs();
+            if window_secs >= 60 {
+                price - oldest_p
+            } else {
+                dec!(0)
+            }
+        } else {
+            dec!(0)
+        };
+
+        Kinematics {
+            velocity_5s,
+            velocity_1s,
+            acceleration,
+            drift_60m,
+            drift_10m,
+        }
+    }
+
+    /// Reset the velocity accumulator on reconnect — exactly what `price.rs`
+    /// does in its disconnect branch: zero `prev_velocity` and clear the 10m
+    /// history (the 5s / 60m histories self-trim by elapsed time).
+    pub fn reset_velocity(&mut self) {
+        self.prev_velocity = dec!(0);
+        self.price_history_10m.clear();
+    }
+}
+
+impl Default for PriceKinematics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::Duration;
+
+    #[test]
+    fn velocity_over_primary_window() {
+        let mut k = PriceKinematics::new();
+        let t0 = Instant::now();
+
+        // First tick: no prior history, all zeros.
+        let a = k.on_price(t0, dec!(100));
+        assert_eq!(a.velocity_5s, dec!(0));
+        assert_eq!(a.velocity_1s, dec!(0));
+        assert_eq!(a.acceleration, dec!(0));
+
+        // +2s, price +10: front is still t0 within the 5s window.
+        let b = k.on_price(t0 + Duration::from_secs(2), dec!(110));
+        assert_eq!(b.velocity_5s, dec!(10)); // 110 - 100
+        assert_eq!(b.velocity_1s, dec!(0)); // only the fresh tick is <1s old
+        assert_eq!(b.acceleration, dec!(10)); // 10 - 0
+
+        // +6s: the t0 entry (age 6 ≥ 5) is trimmed; front becomes the +2s@110.
+        let c = k.on_price(t0 + Duration::from_secs(6), dec!(120));
+        assert_eq!(c.velocity_5s, dec!(10)); // 120 - 110
+        assert_eq!(c.acceleration, dec!(0)); // 10 - 10
+    }
+
+    #[test]
+    fn drift_10m_requires_60s_of_history() {
+        let mut k = PriceKinematics::new();
+        let t0 = Instant::now();
+
+        k.on_price(t0, dec!(100));
+        // Under 60s of history → drift_10m stays 0.
+        let short = k.on_price(t0 + Duration::from_secs(30), dec!(130));
+        assert_eq!(short.drift_10m, dec!(0));
+
+        // Fresh accumulator, ≥60s span → drift_10m becomes active.
+        let mut k2 = PriceKinematics::new();
+        k2.on_price(t0, dec!(100));
+        let long = k2.on_price(t0 + Duration::from_secs(65), dec!(130));
+        assert_eq!(long.drift_10m, dec!(30)); // 130 - 100
+    }
+
+    #[test]
+    fn drift_60m_requires_full_hour() {
+        let mut k = PriceKinematics::new();
+        let t0 = Instant::now();
+
+        k.on_price(t0, dec!(100));
+        // 10 minutes in — not yet an hour, so 60m drift is still 0.
+        let mid = k.on_price(t0 + Duration::from_secs(600), dec!(180));
+        assert_eq!(mid.drift_60m, dec!(0));
+
+        // A full hour of span → 60m drift activates against the oldest point.
+        let mut k2 = PriceKinematics::new();
+        k2.on_price(t0, dec!(100));
+        let hour = k2.on_price(t0 + Duration::from_secs(3600), dec!(250));
+        assert_eq!(hour.drift_60m, dec!(150)); // 250 - 100
+    }
+
+    #[test]
+    fn reset_velocity_zeros_accumulator_and_clears_10m() {
+        let mut k = PriceKinematics::new();
+        let t0 = Instant::now();
+
+        k.on_price(t0, dec!(100));
+        k.on_price(t0 + Duration::from_secs(65), dec!(130));
+
+        k.reset_velocity();
+
+        // After reset the acceleration derivative restarts from 0, and the 10m
+        // history was cleared so drift_10m needs to rebuild its 60s window.
+        let after = k.on_price(t0 + Duration::from_secs(66), dec!(140));
+        // velocity_5s here: 5s window still holds the +65s@130 tick (age 1s),
+        // so 140 - 130 = 10, and acceleration = 10 - 0 (reset) = 10.
+        assert_eq!(after.acceleration, after.velocity_5s);
+        assert_eq!(after.drift_10m, dec!(0));
+    }
+}

--- a/src/raptors/mod.rs
+++ b/src/raptors/mod.rs
@@ -25,3 +25,13 @@ pub mod price;
 pub mod funding;
 pub mod derivatives;
 pub mod tide;
+
+/// Market-data source selection + centralized per-venue symbol resolution.
+pub mod source;
+/// Shared velocity / acceleration / drift math (used by price + hyperliquid).
+pub mod kinematics;
+
+/// Hyperliquid raptor — one WS task per asset feeding every raptor channel.
+/// Gated behind the additive `hyperliquid` cargo feature (pulls in the SDK).
+#[cfg(feature = "hyperliquid")]
+pub mod hyperliquid;

--- a/src/raptors/price.rs
+++ b/src/raptors/price.rs
@@ -16,21 +16,23 @@
 ///     keepalive pings reset the 30s timer but ticker text has silently stopped
 ///
 /// Consumers should treat a `dec!(0)` oracle price as "not yet connected".
+///
+/// The velocity / acceleration / drift math lives in `kinematics::PriceKinematics`
+/// so the Hyperliquid raptor derives byte-identical signals from its trade feed.
 use std::str::FromStr;
 use std::collections::HashMap;
 
 use futures::StreamExt as _;
 use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use tokio::sync::watch;
 use tokio::time::{Duration, Instant, timeout as tokio_timeout};
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use tracing::{info, warn};
-use std::collections::VecDeque;
 use std::sync::Arc;
 
-use crate::config;
 use crate::api::server::AssetRaptorHealth;
+use crate::raptors::kinematics::PriceKinematics;
+use crate::raptors::source;
 
 pub async fn run_price_raptor(
     crypto_filter: String,
@@ -41,16 +43,10 @@ pub async fn run_price_raptor(
     drift_tx: watch::Sender<(Decimal, Decimal)>,
     raptor_health_tx: Arc<watch::Sender<HashMap<String, AssetRaptorHealth>>>,
 ) {
-    let binance_pair = match crypto_filter.as_str() {
-        "eth" => "ethusdt",
-        "sol" => "solusdt",
-        _     => "btcusdt",
-    };
+    let binance_pair = source::binance_ws_pair(&crypto_filter);
     let url_str = format!("wss://stream.binance.com:9443/ws/{}@ticker", binance_pair);
-    let mut price_history: VecDeque<(Instant, Decimal)> = VecDeque::new();
-    let mut price_history_60m: VecDeque<(Instant, Decimal)> = VecDeque::new();
-    let mut price_history_10m: VecDeque<(Instant, Decimal)> = VecDeque::new();
-    let mut prev_velocity = dec!(0);
+    // Rolling velocity/accel/drift accumulator — shared math with the HL raptor.
+    let mut kin = PriceKinematics::new();
 
     loop {
         if let Ok((mut ws_stream, _)) = connect_async(&url_str).await {
@@ -83,86 +79,22 @@ pub async fn run_price_raptor(
                                         let now = Instant::now();
                                         last_price_tick = now; // reset staleness clock
                                         let _ = oracle_tx.send(price);
-                                        price_history.push_back((now, price));
 
-                                        // Trim entries older than the primary window (5s)
-                                        while let Some((t, _)) = price_history.front() {
-                                            if now.duration_since(*t).as_secs() >= config::MOMENTUM_WINDOW_SECS {
-                                                price_history.pop_front();
-                                            } else { break; }
-                                        }
-
-                                        // Primary velocity (5s window)
-                                        let velocity_5s = if let Some((_, start_price)) = price_history.front() {
-                                            price - start_price
-                                        } else { dec!(0) };
-
-                                        // Short velocity (1s window)
-                                        let velocity_1s = {
-                                            let cutoff = config::MOMENTUM_SHORT_WINDOW_SECS;
-                                            let start_1s = price_history.iter()
-                                                .find(|(t, _)| now.duration_since(*t).as_secs() < cutoff);
-                                            match start_1s {
-                                                Some((_, p)) => price - p,
-                                                None => velocity_5s,
-                                            }
-                                        };
-
-                                        // Acceleration: rate of change of velocity
-                                        let acceleration = velocity_5s - prev_velocity;
-                                        prev_velocity = velocity_5s;
-                                        let _ = velocity_tx.send((velocity_5s, velocity_1s, acceleration));
-
-                                        // 60-minute drift
-                                        price_history_60m.push_back((now, price));
-                                        while let Some((t, _)) = price_history_60m.front() {
-                                            if now.duration_since(*t).as_secs() > 3600 {
-                                                price_history_60m.pop_front();
-                                            } else { break; }
-                                        }
-                                        let drift_60m = if price_history_60m.len() > 1 {
-                                            if let Some((oldest_t, oldest_p)) = price_history_60m.front() {
-                                                if now.duration_since(*oldest_t).as_secs() >= 3600 {
-                                                    price - oldest_p
-                                                } else { dec!(0) }
-                                            } else { dec!(0) }
-                                        } else { dec!(0) };
-
-                                        // 10-minute drift — fills the 5s–60m gap for GBoost feature [18].
-                                        // Captures the medium-term trend where profitable binary moves develop.
-                                        //
-                                        // Previously returned dec!(0) unless exactly 10 minutes of history
-                                        // were available.  Fixed: if at least 60 seconds of data exists,
-                                        // return the drift over whatever window IS available.  This ensures
-                                        // the momentum 10m-drift gate is active from the second minute
-                                        // rather than silent for the entire first 10 minutes of a session.
-                                        price_history_10m.push_back((now, price));
-                                        while let Some((t, _)) = price_history_10m.front() {
-                                            if now.duration_since(*t).as_secs() > 600 {
-                                                price_history_10m.pop_front();
-                                            } else { break; }
-                                        }
-                                        let drift_10m = if let Some((oldest_t, oldest_p)) = price_history_10m.front() {
-                                            let window_secs = now.duration_since(*oldest_t).as_secs();
-                                            // Require at least 60s of history before trusting the drift.
-                                            // Below that, the window is too short to distinguish noise from trend.
-                                            if window_secs >= 60 {
-                                                price - oldest_p
-                                            } else { dec!(0) }
-                                        } else { dec!(0) };
-
-                                        let _ = drift_tx.send((drift_60m, drift_10m));
+                                        // Derive velocity / acceleration / drift.
+                                        let sig = kin.on_price(now, price);
+                                        let _ = velocity_tx.send((sig.velocity_5s, sig.velocity_1s, sig.acceleration));
+                                        let _ = drift_tx.send((sig.drift_60m, sig.drift_10m));
 
                                         // Mirror the latest signal snapshot into the shared
                                         // raptor-health map so GET /api/telemetry can graph it.
                                         raptor_health_tx.send_modify(|map| {
                                             let h = map.entry(crypto_filter.clone()).or_default();
                                             h.oracle_price = price;
-                                            h.velocity_5s  = velocity_5s;
-                                            h.velocity_1s  = velocity_1s;
-                                            h.acceleration = acceleration;
-                                            h.drift_60m    = drift_60m;
-                                            h.drift_10m    = drift_10m;
+                                            h.velocity_5s  = sig.velocity_5s;
+                                            h.velocity_1s  = sig.velocity_1s;
+                                            h.acceleration = sig.acceleration;
+                                            h.drift_60m    = sig.drift_60m;
+                                            h.drift_10m    = sig.drift_10m;
                                         });
                                     }
                                 }
@@ -184,8 +116,7 @@ pub async fn run_price_raptor(
         raptor_health_tx.send_modify(|map| {
             map.entry(crypto_filter.clone()).or_default().price_connected = false;
         });
-        prev_velocity = dec!(0);
-        price_history_10m.clear();
+        kin.reset_velocity();
         tokio::time::sleep(Duration::from_secs(5)).await;
     }
 }

--- a/src/raptors/source.rs
+++ b/src/raptors/source.rs
@@ -1,0 +1,216 @@
+//! Market-data source selection + per-source symbol resolution.
+//!
+//! DRADIS reads live crypto telemetry (spot price, velocity, funding, open
+//! interest, taker flow) from a market-data *source*. Historically that was
+//! always Binance; this module makes the source runtime-selectable so an
+//! operator can point the raptor layer at Hyperliquid instead (e.g. in regions
+//! where Binance is unreachable) without touching any strategy code — the
+//! raptors feed the SAME `watch` channels regardless of source.
+//!
+//! Selection precedence (highest first):
+//!   1. `MARKET_DATA_SOURCE` env var
+//!   2. `config::MARKET_DATA_SOURCE` compile-time constant
+//!   3. `Binance` (hard default — existing deployments are unchanged)
+//!
+//! Degrade-don't-panic (repo convention): an unknown value, or `hyperliquid`
+//! selected in a build without the `hyperliquid` cargo feature, logs an
+//! `error!` listing the valid values and falls back to Binance.
+//!
+//! This module also centralises the per-venue symbol resolution that was
+//! previously duplicated across `price.rs`, `funding.rs`, `derivatives.rs`, and
+//! `helpers/time.rs` (six near-identical `match` blocks). The Binance
+//! resolvers preserve the exact `_ => btc` fallback of those sites so behaviour
+//! is byte-identical when the source is unset.
+
+use tracing::error;
+
+use crate::config;
+
+/// Which external market-data source the raptor layer reads from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MarketDataSource {
+    /// Binance Spot WS (price) + Binance FAPI REST (funding, OI/CVD). Default.
+    Binance,
+    /// Hyperliquid Info API — one WS raptor per asset (trades + activeAssetCtx).
+    Hyperliquid,
+}
+
+impl MarketDataSource {
+    /// Resolve the active source from `MARKET_DATA_SOURCE` env → config → Binance.
+    pub fn resolve() -> Self {
+        Self::resolve_with(
+            std::env::var("MARKET_DATA_SOURCE").ok().as_deref(),
+            config::MARKET_DATA_SOURCE,
+        )
+    }
+
+    /// Precedence-aware resolution split out for unit testing (env > config).
+    fn resolve_with(env_val: Option<&str>, config_val: &str) -> Self {
+        let raw = env_val
+            .map(str::to_string)
+            .unwrap_or_else(|| config_val.to_string());
+        Self::parse(&raw)
+    }
+
+    /// Parse a raw source string, applying the degrade-don't-panic fallbacks.
+    fn parse(raw: &str) -> Self {
+        match raw.trim().to_lowercase().as_str() {
+            "binance" => MarketDataSource::Binance,
+            "hyperliquid" => {
+                #[cfg(feature = "hyperliquid")]
+                {
+                    MarketDataSource::Hyperliquid
+                }
+                #[cfg(not(feature = "hyperliquid"))]
+                {
+                    error!(
+                        "⚠️ MARKET_DATA_SOURCE=hyperliquid but this build was compiled \
+                         without the `hyperliquid` cargo feature — falling back to Binance. \
+                         Rebuild with default features (or `--features hyperliquid`) to enable it."
+                    );
+                    MarketDataSource::Binance
+                }
+            }
+            other => {
+                error!(
+                    "⚠️ Unknown MARKET_DATA_SOURCE '{}' (valid: binance | hyperliquid) — \
+                     falling back to Binance.",
+                    other
+                );
+                MarketDataSource::Binance
+            }
+        }
+    }
+
+    /// Canonical lowercase identifier for logs, telemetry, and the status API.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MarketDataSource::Binance => "binance",
+            MarketDataSource::Hyperliquid => "hyperliquid",
+        }
+    }
+}
+
+// ─── Centralised venue-symbol resolution ────────────────────────────────────
+//
+// These replace the six duplicated `match crypto_filter { … }` blocks that used
+// to live in price.rs / funding.rs / derivatives.rs / helpers/time.rs. The
+// `_ => btc` fallback is preserved verbatim from those sites so an unrecognised
+// asset slug keeps resolving to BTC exactly as before.
+
+/// Binance Spot WS pair (lowercase), e.g. `"btc"` → `"btcusdt"`.
+pub fn binance_ws_pair(asset: &str) -> String {
+    match asset {
+        "eth" => "ethusdt",
+        "sol" => "solusdt",
+        _ => "btcusdt",
+    }
+    .to_string()
+}
+
+/// Binance REST/FAPI symbol (uppercase), e.g. `"btc"` → `"BTCUSDT"`.
+pub fn binance_symbol(asset: &str) -> String {
+    match asset {
+        "eth" => "ETHUSDT",
+        "sol" => "SOLUSDT",
+        _ => "BTCUSDT",
+    }
+    .to_string()
+}
+
+/// Hyperliquid perp coin (uppercase, plain symbol), e.g. `"btc"` → `"BTC"`.
+pub fn hyperliquid_coin(asset: &str) -> String {
+    match asset {
+        "eth" => "ETH",
+        "sol" => "SOL",
+        _ => "BTC",
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_precedence_env_over_config() {
+        // Explicit env value wins over the config default.
+        assert_eq!(
+            MarketDataSource::resolve_with(Some("binance"), "hyperliquid"),
+            MarketDataSource::Binance
+        );
+        // Falls back to config when env is absent.
+        assert_eq!(
+            MarketDataSource::resolve_with(None, "binance"),
+            MarketDataSource::Binance
+        );
+    }
+
+    #[test]
+    fn resolve_unknown_value_falls_back_to_binance() {
+        assert_eq!(
+            MarketDataSource::resolve_with(Some("coinbase"), "binance"),
+            MarketDataSource::Binance
+        );
+        assert_eq!(
+            MarketDataSource::resolve_with(None, "garbage"),
+            MarketDataSource::Binance
+        );
+    }
+
+    #[test]
+    fn parse_is_case_and_whitespace_insensitive() {
+        assert_eq!(MarketDataSource::parse("  BINANCE  "), MarketDataSource::Binance);
+    }
+
+    #[cfg(feature = "hyperliquid")]
+    #[test]
+    fn resolve_hyperliquid_when_feature_enabled() {
+        assert_eq!(
+            MarketDataSource::resolve_with(Some("hyperliquid"), "binance"),
+            MarketDataSource::Hyperliquid
+        );
+        assert_eq!(
+            MarketDataSource::parse("HyperLiquid"),
+            MarketDataSource::Hyperliquid
+        );
+    }
+
+    #[cfg(not(feature = "hyperliquid"))]
+    #[test]
+    fn resolve_hyperliquid_falls_back_without_feature() {
+        assert_eq!(
+            MarketDataSource::resolve_with(Some("hyperliquid"), "binance"),
+            MarketDataSource::Binance
+        );
+    }
+
+    #[test]
+    fn as_str_roundtrip() {
+        assert_eq!(MarketDataSource::Binance.as_str(), "binance");
+        assert_eq!(MarketDataSource::Hyperliquid.as_str(), "hyperliquid");
+    }
+
+    #[test]
+    fn binance_symbol_resolution_matches_legacy_fallback() {
+        assert_eq!(binance_ws_pair("btc"), "btcusdt");
+        assert_eq!(binance_ws_pair("eth"), "ethusdt");
+        assert_eq!(binance_ws_pair("sol"), "solusdt");
+        // Unknown slug preserves the historical `_ => btc` fallback.
+        assert_eq!(binance_ws_pair("doge"), "btcusdt");
+
+        assert_eq!(binance_symbol("btc"), "BTCUSDT");
+        assert_eq!(binance_symbol("eth"), "ETHUSDT");
+        assert_eq!(binance_symbol("sol"), "SOLUSDT");
+        assert_eq!(binance_symbol("doge"), "BTCUSDT");
+    }
+
+    #[test]
+    fn hyperliquid_coin_resolution() {
+        assert_eq!(hyperliquid_coin("btc"), "BTC");
+        assert_eq!(hyperliquid_coin("eth"), "ETH");
+        assert_eq!(hyperliquid_coin("sol"), "SOL");
+        // Unknown slug preserves the `_ => btc` fallback.
+        assert_eq!(hyperliquid_coin("doge"), "BTC");
+    }
+}

--- a/src/squadron/patrol_impl.rs
+++ b/src/squadron/patrol_impl.rs
@@ -5,10 +5,11 @@
 ///
 /// Phase 3f-4: peripheral tickers (pulse, settlement, cleanup, status, watchdog)
 /// are lifted into independent Tokio tasks spawned via `patrol_tasks.rs`.
-/// The core `select!` now has exactly three arms:
-///   1. `cancel.cancelled()`       — CAG/watchdog stand-down
-///   2. `ctx.market_rx.changed()`  — market rotation
-///   3. `ticker.tick()`            — strategy evaluation
+/// The core `select!` now has four arms:
+///   1. `cancel.cancelled()`             — CAG/watchdog stand-down
+///   2. `ctx.market_rx.changed()`        — market rotation
+///   3. `config_reload_ticker.tick()`    — periodic squadron-config reload
+///   4. `ticker.tick()`                  — strategy evaluation
 
 use std::str::FromStr as _;
 use std::sync::Arc;
@@ -36,6 +37,7 @@ use crate::orchestrator::executor::{execute_strategies_concurrent, aggregate_and
 use crate::helpers::{
     balance::*, orders::*,
     notifications::{send_notification, tweet_trade}, metrics, db,
+    dynamic_config::DynamicConfig,
 };
 use crate::squadron::Squadron;
 use super::context::PatrolContext;
@@ -51,6 +53,30 @@ const EXCHANGE_NEG_RISK: Address = address!("0xe2222d279d744050d28e0052001052000
 
 const MAX_CANCEL_RETRIES: u32 = 5;
 const BASE_CANCEL_RETRY_DELAY_MS: u64 = 200;
+
+/// How often the intl patrol reloads its squadron-scoped `DynamicConfig` from the
+/// DB so Control Tower edits (e.g. the GHOST/LIVE toggle or a viper enable flag)
+/// take effect on a *running* squadron without waiting for the next hourly market
+/// rotation. Mirrors the us_retail venue's `DASHBOARD_SYNC_SECS` reload
+/// (`venues/us/trader.rs`).
+const SQUADRON_CONFIG_RELOAD_SECS: u64 = 30;
+
+/// A simulated resting ghost maker BUY quote (D5).
+///
+/// Held in the patrol loop's local registry keyed by `(strategy, token)`. Each
+/// patrol tick advances `consecutive_ticks` while the market's best bid sits at or
+/// below the quote price; once it has rested `config::PAPER_MAKER_FILL_TICKS` ticks
+/// the quote is treated as filled — a documented queue-position heuristic replacing
+/// the old instant ghost maker fill.
+#[derive(Clone)]
+struct GhostRestingQuote {
+    price: Decimal,
+    shares: Decimal,
+    market_name: String,
+    /// "YES" / "NO" — captured at registration for the entries/open_positions rows.
+    side: String,
+    consecutive_ticks: u64,
+}
 
 impl Squadron {
     /// Run the squadron's full patrol lifecycle.
@@ -79,6 +105,8 @@ impl Squadron {
         let positions             = ctx.session.positions.clone();
         let pending_orders        = ctx.session.pending_orders.clone();
         let total_pnl             = ctx.session.total_pnl.clone();
+        let paper_pnl             = ctx.session.paper_pnl.clone();
+        let paper_balance         = ctx.session.paper_balance.clone();
         let live_collateral       = ctx.session.live_collateral.clone();
         let starting_collateral_store = ctx.session.starting_collateral.clone();
         let phantom_cooldowns     = ctx.session.phantom_cooldowns.clone();
@@ -219,6 +247,10 @@ impl Squadron {
             tg_token.clone(),
             tg_chat_id.clone(),
             asset_lc.clone(),
+            oracle_rx.clone(),
+            hourly_strike_price,
+            paper_pnl.clone(),
+            paper_balance.clone(),
             peripheral_cancel.clone(),
         );
 
@@ -370,7 +402,15 @@ impl Squadron {
         let patrol_venue = std::sync::Arc::clone(&ctx.session.venue);
 
         // ── Core tick loop: 3 arms ────────────────────────────────────────────
+        // D5: simulated resting ghost maker quotes. Local to this patrol() call, so
+        // it is dropped (all quotes cancelled) on every market rotation — the same
+        // net effect as live GTC orders being cancelled at rotation.
+        let mut ghost_maker_quotes: std::collections::HashMap<(String, MarketId), GhostRestingQuote> =
+            std::collections::HashMap::new();
         let mut ticker = interval(config::main_ticker_interval());
+        // Periodic squadron-config reload (see SQUADRON_CONFIG_RELOAD_SECS). Lets
+        // Control Tower edits reach this running patrol between market rotations.
+        let mut config_reload_ticker = interval(Duration::from_secs(SQUADRON_CONFIG_RELOAD_SECS));
         loop {
             tokio::select! {
                 biased;
@@ -401,6 +441,50 @@ impl Squadron {
                         continue;
                     }
                     info!("🔄 Market switch detected — restarting trading loop with new market context");
+
+                    // D6 fix: settle GHOST (paper) positions for the market(s) being rotated
+                    // away, BEFORE this patrol tears down. Hourly markets rotate ~12 min before
+                    // close — far outside cleanup_expired_positions' 60s settlement window — and
+                    // the per-patrol cleanup task dies with the patrol, so without this ghost
+                    // positions strand in the shared position map with paper collateral
+                    // permanently debited. `force = true` settles regardless of the window and
+                    // removes ONLY ghost legs; live positions are grandfathered / settled on-chain.
+                    {
+                        let oracle_now = *oracle_rx.borrow();
+                        if new_hourly_condition_id != current_hourly_cid
+                            && hourly_yes_token != market_id_from_u256(U256::ZERO)
+                        {
+                            crate::tasks::cleanup::cleanup_expired_positions(
+                                Arc::clone(&positions),
+                                hourly_market_name.clone(),
+                                hourly_yes_token.clone(), hourly_no_token.clone(),
+                                hourly_market_close_time,
+                                hourly_strike_price,
+                                oracle_now,
+                                Arc::clone(&paper_pnl),
+                                Arc::clone(&paper_balance),
+                                asset_lc.clone(),
+                                true,
+                            ).await;
+                        }
+                        if let Some(ref mk) = maker_market_config {
+                            if new_maker_cid != current_maker_cid {
+                                crate::tasks::cleanup::cleanup_expired_positions(
+                                    Arc::clone(&positions),
+                                    mk.market_name.clone(),
+                                    mk.yes_token.clone(), mk.no_token.clone(),
+                                    mk.market_close_time,
+                                    mk.strike_price,
+                                    oracle_now,
+                                    Arc::clone(&paper_pnl),
+                                    Arc::clone(&paper_balance),
+                                    asset_lc.clone(),
+                                    true,
+                                ).await;
+                            }
+                        }
+                    }
+
                     let mut cancel_success = false;
                     for i in 0..MAX_CANCEL_RETRIES {
                         let delay = BASE_CANCEL_RETRY_DELAY_MS * (1 << i);
@@ -442,7 +526,28 @@ impl Squadron {
                     self.cancel_ws();
                     break;
                 }
-                // ── 3. Strategy evaluation tick ─────────────────────────────────
+                // ── 3. Periodic squadron-config reload ──────────────────────────
+                // Refresh ctx.dynamic_config from this squadron's DB row so a
+                // Control Tower toggle (GHOST/LIVE, viper enable, tuning) applied
+                // via PATCH /api/config (fanned out per-squadron) or
+                // PATCH /api/squadrons/{id}/config lands on the live patrol within
+                // ~SQUADRON_CONFIG_RELOAD_SECS instead of only on the next rotation.
+                _ = config_reload_ticker.tick() => {
+                    // Load first (async DB read), THEN take the write guard. The
+                    // guard is a std RwLock, not tokio's — it must never be held
+                    // across an .await, so the load completes before we lock.
+                    let reloaded = DynamicConfig::load_for_squadron(&self.id).await;
+                    let ghost_changed = {
+                        let mut guard = dynamic_config.write().unwrap();
+                        let prev_ghost = guard.ghost_mode;
+                        *guard = (*reloaded).clone();
+                        prev_ghost != guard.ghost_mode
+                    };
+                    if ghost_changed {
+                        debug!("⚙️  Squadron [{}] config reload: ghost_mode → {}", self.id, reloaded.ghost_mode);
+                    }
+                }
+                // ── 4. Strategy evaluation tick ─────────────────────────────────
                 _ = ticker.tick() => {
                     // Skip evaluation this tick if the market has changed — yield to arm 2.
                     if ctx.market_rx.has_changed().unwrap_or(false) { continue; }
@@ -531,6 +636,13 @@ impl Squadron {
                         }),
                         dynamic_config: dyn_cfg,
                         arb_market_lockouts: Some(arb_market_lockouts.clone()),
+                        // Clock seam (W1): capture one consistent now for all viper
+                        // gates this tick. Behaviour-identical to the pre-seam direct
+                        // Utc::now()/Instant::now() calls, just sampled once here.
+                        wall_now: Utc::now(),
+                        mono_now: std::time::Instant::now(),
+                        // Live patrol — never a replay; vipers may consult live DB state.
+                        is_replay: false,
                     };
 
                     let eval_result = match execute_strategies_concurrent(&strategies, &ctx, 500, &mut last_executor_summary).await {
@@ -538,7 +650,10 @@ impl Squadron {
                         Err(e) => { warn!("⚠️ Strategy evaluation error: {}", e); continue; }
                     };
                     let (resolved_signals, _) = aggregate_and_resolve_signals(&eval_result);
-                    if resolved_signals.is_empty() { continue; }
+                    // NOTE: do NOT `continue` on empty signals here — the D5 resting-ghost-quote
+                    // advance/fill sweep at the tail of this arm must run EVERY tick so quotes
+                    // accrue queue time even on ticks that produced no new signals. An empty
+                    // `resolved_signals` simply makes the for-loop below a no-op.
 
                     // ── Signal-processing timeout guard (45 s) ───────────────────────
                     let signal_processing_result = tokio::time::timeout(Duration::from_secs(45), async {
@@ -568,14 +683,46 @@ impl Squadron {
                                 let tid = params.token_id;
                                 let tid_m = tid.clone(); // neutral key (slice 2a)
                                 let pos_key = (sn.clone(), tid_m.clone());
-                                let shares = { let map = positions.lock().await; match map.get(&pos_key) { Some(p) => p.shares, None => continue } };
+                                // Position-scoped mode: exits key off the mode the position was
+                                // OPENED under (D1), never the current toggle.
+                                let (shares, pos_ghost) = { let map = positions.lock().await; match map.get(&pos_key) { Some(p) => (p.shares, p.ghost), None => continue } };
                                 if shares < config::MIN_ORDER_SHARES || params.price <= dec!(0) {
-                                    let mut map = positions.lock().await; if let Some(p) = map.remove(&pos_key) { let aep = (params.price - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE); *total_pnl.lock().await += (aep - p.avg_entry) * p.shares; } continue;
+                                    let removed = { let mut map = positions.lock().await; map.remove(&pos_key) };
+                                    if let Some(p) = removed {
+                                        let aep = (params.price - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE);
+                                        let pnl = (aep - p.avg_entry) * p.shares;
+                                        if p.ghost {
+                                            *paper_pnl.lock().await += pnl;
+                                            *paper_balance.lock().await += aep * p.shares;
+                                            // Release the token claim and write the same DB trail a normal
+                                            // ghost exit does (trades row + open_positions delete). Without
+                                            // this the paper ledger moves but SUM(pnl) over ghost trades
+                                            // diverges and the open_positions row is left to the stale-purge.
+                                            token_ownership.lock().await.remove(&tid_m);
+                                            if p.shares > dec!(0) {
+                                                let side_d = if tid == target_yes_token { "YES".to_string() } else { "NO".to_string() };
+                                                let m_name = params.market_name.clone();
+                                                let r_d = reason.clone();
+                                                let asset_d = asset_lc.clone();
+                                                let sn_d = sn.clone();
+                                                let sn_close = sn.clone();
+                                                let tid_close = tid_m.clone();
+                                                let re_d = p.avg_entry; let sh_d = p.shares;
+                                                tokio::spawn(async move {
+                                                    metrics::record_trade(&asset_d, sn_d, m_name, side_d, re_d, aep, sh_d, pnl, r_d, true).await;
+                                                    if let Some(pool) = db::pool_for(&asset_d) { db::close_open_position(&pool, &sn_close, &tid_close.to_string()).await; }
+                                                });
+                                            }
+                                        } else {
+                                            *total_pnl.lock().await += pnl;
+                                        }
+                                    }
+                                    continue;
                                 }
                                 info!("🔴 EXIT [{}]: {} | shares={:.2}, bid=${:.4} | {}", sn, params.market_name, shares, params.price, reason);
                                 let vc = if target_is_neg_risk { EXCHANGE_NEG_RISK } else { EXCHANGE_NORMAL };
 
-                                if !config::GHOST_MODE {
+                                if !pos_ghost {
                                     if let Err(e) = place_limit_order(&trading_client, &nonce_manager, &signer, safe_address, eoa_address, vc, &tid, Side::Sell, shares, (params.price - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE), target_yes_fee_bps as u16, params.order_type, params.post_only, 0, &shared_http).await {
                                         let es = e.to_string();
                                         if es.contains("not enough balance") || es.contains("balance: 0") || es.contains("invalid price") {
@@ -600,28 +747,74 @@ impl Squadron {
                                             let rs_m;
                                             let rc_m;
                                             let pnl_m;
+                                            let exit_avg_m;
+
+                                            // Exit-side bid depth for the primary leg, from the venue-appropriate
+                                            // snapshot — used only by the ghost depth-aware fill simulation (D4).
+                                            let primary_exit_snap = if target_yes_token == ctx.market.yes_token {
+                                                &ctx.snapshot
+                                            } else {
+                                                ctx.maker_snapshot.as_ref().unwrap_or(&ctx.snapshot)
+                                            };
+                                            let primary_bid_depth = if tid == target_yes_token { primary_exit_snap.yes_bid_depth } else { primary_exit_snap.no_bid_depth };
 
                                             {
                                                 let mut map = positions.lock().await;
                                                 if let Some(p) = map.remove(&pos_key) {
-                                                    let actual_exit_price = (params.price - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE);
+                                                    // LIVE: exact prior behaviour — booked at (bid − offset), floored.
+                                                    // GHOST: depth-aware simulated fill (D4) — worse on the overflow tranche.
+                                                    let live_exit_price = (params.price - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE);
+                                                    let actual_exit_price = if pos_ghost {
+                                                        crate::helpers::paper::simulate_taker_sell_avg(
+                                                            live_exit_price, primary_bid_depth, p.shares,
+                                                            config::PAPER_OVERFLOW_SLIPPAGE, config::MIN_SELL_LIMIT_PRICE,
+                                                        )
+                                                    } else {
+                                                        live_exit_price
+                                                    };
                                                     let pnl = (actual_exit_price - p.avg_entry) * p.shares;
-                                                    *total_pnl.lock().await += pnl;
+                                                    if pos_ghost {
+                                                        // Paper accounting: segregated P&L + collateral credit (D7).
+                                                        *paper_pnl.lock().await += pnl;
+                                                        *paper_balance.lock().await += actual_exit_price * p.shares;
+                                                    } else {
+                                                        *total_pnl.lock().await += pnl;
+                                                    }
 
                                                     re_m = p.avg_entry;
                                                     rs_m = p.shares;
                                                     rc_m = p.close_time;
                                                     pnl_m = pnl;
+                                                    exit_avg_m = actual_exit_price;
 
-                                                    // NOTE: record_trade and close_open_position are deferred
-                                                    // to the FAK verification block below so we only write to
-                                                    // the DB once the fill is confirmed (not on order placement).
+                                                    // NOTE: for LIVE, record_trade and close_open_position are deferred
+                                                    // to the FAK verification block below so we only write to the DB
+                                                    // once the fill is confirmed (not on order placement). For GHOST
+                                                    // the fill is simulated, so we record immediately below.
                                                 } else { continue; }
                                             }
                                             // Release token claim — position is fully closed.
                                             token_ownership.lock().await.remove(&tid_m);
 
-                                        if rs_m > dec!(0) && !config::GHOST_MODE {
+                                        if pos_ghost {
+                                            // GHOST: no on-chain reconcile. Write the same DB trail a live exit
+                                            // does (trades row + open_positions delete) with the simulated
+                                            // proceeds, so ghost exits no longer strand open_positions rows (W2/D7).
+                                            if rs_m > dec!(0) {
+                                                let sid_m = if tid == target_yes_token { "YES".to_string() } else { "NO".to_string() };
+                                                let m_name = params.market_name.clone();
+                                                let r_m = reason.clone();
+                                                let asset_t = asset_lc.clone();
+                                                let sn_rec = sn.clone();
+                                                let sn_async = sn.clone();
+                                                let tid_async = tid_m.clone();
+                                                info!("👻 [PAPER] EXIT confirmed [{sn_async}]: {rs_m:.4} shares @ ${exit_avg_m:.4} pnl=${pnl_m:.4} (simulated)");
+                                                tokio::spawn(async move {
+                                                    metrics::record_trade(&asset_t, sn_rec, m_name, sid_m, re_m, exit_avg_m, rs_m, pnl_m, r_m, true).await;
+                                                    if let Some(pool) = db::pool_for(&asset_t) { db::close_open_position(&pool, &sn_async, &tid_async.to_string()).await; }
+                                                });
+                                            }
+                                        } else if rs_m > dec!(0) {
                                             let ps = Arc::clone(&positions); let cl = Arc::clone(&trading_client); let tp = Arc::clone(&total_pnl); let m_name = params.market_name.clone();
                                             let sn_async = sn.clone();
                                             let tid_async = tid_m.clone(); // neutral key moved into the spawn
@@ -631,7 +824,7 @@ impl Squadron {
                                             let r_m = reason.clone();
                                             let asset_t = asset_lc.clone();
                                             let sn_rec = sn.clone();
-                                            let tid_rec = tid.to_string();
+                                            let _tid_rec = tid.to_string();
                                             tokio::spawn(async move {
                                                 tokio::time::sleep(Duration::from_millis(2500)).await;
                                                 let mut req = BalanceAllowanceRequest::default(); req.asset_type = AssetType::Conditional; req.token_id = Some(u256_from_market_id(&tid_async).unwrap_or_default());
@@ -640,7 +833,11 @@ impl Squadron {
                                                 let other_strats_shares = {
                                                     let map = ps.lock().await;
                                                     map.iter()
-                                                        .filter(|((s, t), _)| *t == tid_async && s != &sn_async)
+                                                        // GHOST positions have no on-chain counterpart, so they must
+                                                        // NOT be subtracted from the wallet's real remaining balance —
+                                                        // counting them would understate our_rem and fabricate a
+                                                        // partial live exit against untracked on-chain shares.
+                                                        .filter(|((s, t), p)| *t == tid_async && s != &sn_async && !p.ghost)
                                                         .map(|(_, p)| p.shares)
                                                         .fold(dec!(0), |a, b| a + b)
                                                 };
@@ -652,24 +849,24 @@ impl Squadron {
                                                         warn!("⚠️ PARTIAL EXIT [{}]: FAK filled 0/{:.4} shares (our_rem={:.4}, other_strats={:.4}) — re-inserting for retry.", sn_async, rs_m, our_rem, other_strats_shares);
                                                         let mut map = ps.lock().await;
                                                         if !map.contains_key(&(sn_async.clone(), tid_async.clone())) {
-                                                            map.insert((sn_async.clone(), tid_async.clone()), Position { shares: our_rem, avg_entry: re_m, opened_at: Utc::now(), close_time: rc_m, market_name: m_name, pair_token_id: tid_async.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: None });
+                                                            map.insert((sn_async.clone(), tid_async.clone()), Position { shares: our_rem, avg_entry: re_m, opened_at: Utc::now(), close_time: rc_m, market_name: m_name, pair_token_id: tid_async.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: None, ghost: false });
                                                         }
                                                         // 0 fills — do NOT record to DB; position is re-inserted for retry.
                                                     } else {
                                                         warn!("⚠️ PARTIAL EXIT [{}]: sold {:.4}/{:.4} (our_rem={:.4}, other_strats={:.4}) — re-inserting.", sn_async, fill, rs_m, our_rem, other_strats_shares);
                                                         let mut map = ps.lock().await;
                                                         if !map.contains_key(&(sn_async.clone(), tid_async.clone())) {
-                                                            map.insert((sn_async.clone(), tid_async.clone()), Position { shares: our_rem, avg_entry: re_m, opened_at: Utc::now(), close_time: rc_m, market_name: m_name.clone(), pair_token_id: tid_async.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: None });
+                                                            map.insert((sn_async.clone(), tid_async.clone()), Position { shares: our_rem, avg_entry: re_m, opened_at: Utc::now(), close_time: rc_m, market_name: m_name.clone(), pair_token_id: tid_async.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: None, ghost: false });
                                                         }
                                                         // Partial fill — record only the filled portion.
                                                         let partial_pnl = (aep2 - re_m) * fill;
-                                                        metrics::record_trade(&asset_t, sn_rec, m_name, sid_m, re_m, aep2, fill, partial_pnl, r_m).await;
+                                                        metrics::record_trade(&asset_t, sn_rec, m_name, sid_m, re_m, aep2, fill, partial_pnl, r_m, false).await;
                                                         if let Some(pool) = db::pool_for(&asset_t) { db::close_open_position(&pool, &sn_async, &tid_async.to_string()).await; }
                                                     }
                                                 } else {
                                                     // Full fill confirmed — now it's safe to write to DB.
                                                     info!("✅ FAK exit confirmed [{sn_async}]: {rs_m:.4} shares sold @ ${aep_exit:.4} pnl=${pnl_m:.4}");
-                                                    metrics::record_trade(&asset_t, sn_rec, m_name, sid_m, re_m, aep_exit, rs_m, pnl_m, r_m).await;
+                                                    metrics::record_trade(&asset_t, sn_rec, m_name, sid_m, re_m, aep_exit, rs_m, pnl_m, r_m, false).await;
                                                     if let Some(pool) = db::pool_for(&asset_t) { db::close_open_position(&pool, &sn_async, &tid_async.to_string()).await; }
                                                 }
                                             });
@@ -678,7 +875,9 @@ impl Squadron {
                                     if exit_pair {
                                         let other_tid = if tid == target_yes_token { target_no_token.clone() } else { target_yes_token.clone() };
                                         let other_tid_m = other_tid.clone(); // neutral key (slice 2a)
-                                        let pk = (sn.clone(), other_tid_m.clone()); let ps = { let map = positions.lock().await; map.get(&pk).map(|p| p.shares) };
+                                        let pk = (sn.clone(), other_tid_m.clone());
+                                        // Paired leg keys off its OWN opened-under mode (D1).
+                                        let (ps, paired_ghost) = { let map = positions.lock().await; match map.get(&pk) { Some(p) => (Some(p.shares), p.ghost), None => (None, false) } };
                                         if let Some(s) = ps {
                                             let exit_snap = if target_yes_token == ctx.market.yes_token {
                                                 &ctx.snapshot
@@ -686,15 +885,32 @@ impl Squadron {
                                                 ctx.maker_snapshot.as_ref().unwrap_or(&ctx.snapshot)
                                             };
                                             let other_bid = if other_tid == target_yes_token { exit_snap.yes_bid } else { exit_snap.no_bid };
+                                            let other_bid_depth = if other_tid == target_yes_token { exit_snap.yes_bid_depth } else { exit_snap.no_bid_depth };
                                             let other_fee_bps = if other_tid == target_yes_token { target_yes_fee_bps as u16 } else { target_no_fee_bps as u16 };
                                             let other_vc = if target_is_neg_risk { EXCHANGE_NEG_RISK } else { EXCHANGE_NORMAL };
-                                                if !config::GHOST_MODE { let _ = place_limit_order(&trading_client, &nonce_manager, &signer, safe_address, eoa_address, other_vc, &other_tid, Side::Sell, s, (other_bid - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE), other_fee_bps, crate::venues::core::TimeInForce::Fak, false, 0, &shared_http).await; }
-                                                    let mut map = positions.lock().await; if let Some(p) = map.remove(&pk) { let actual_other_exit = (other_bid - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE); let pnl = (actual_other_exit - p.avg_entry) * p.shares; paired_pnl = pnl; *total_pnl.lock().await += pnl;
+                                                if !paired_ghost { let _ = place_limit_order(&trading_client, &nonce_manager, &signer, safe_address, eoa_address, other_vc, &other_tid, Side::Sell, s, (other_bid - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE), other_fee_bps, crate::venues::core::TimeInForce::Fak, false, 0, &shared_http).await; }
+                                                    let mut map = positions.lock().await; if let Some(p) = map.remove(&pk) {
+                                                        let live_other_exit = (other_bid - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE);
+                                                        let actual_other_exit = if paired_ghost {
+                                                            crate::helpers::paper::simulate_taker_sell_avg(
+                                                                live_other_exit, other_bid_depth, p.shares,
+                                                                config::PAPER_OVERFLOW_SLIPPAGE, config::MIN_SELL_LIMIT_PRICE,
+                                                            )
+                                                        } else {
+                                                            live_other_exit
+                                                        };
+                                                        let pnl = (actual_other_exit - p.avg_entry) * p.shares; paired_pnl = pnl;
+                                                        if paired_ghost {
+                                                            *paper_pnl.lock().await += pnl;
+                                                            *paper_balance.lock().await += actual_other_exit * p.shares;
+                                                        } else {
+                                                            *total_pnl.lock().await += pnl;
+                                                        }
                                                 // Release paired token claim.
                                                 token_ownership.lock().await.remove(&other_tid_m);
                                                 {
                                                     let sn_pm = sn.clone(); let m_name = params.market_name.clone(); let sid = if other_tid == target_yes_token { "YES".to_string() } else { "NO".to_string() }; let p_avg = p.avg_entry; let o_bid = actual_other_exit; let p_shares = p.shares; let pn = pnl; let asset_t = asset_lc.clone();
-                                                    tokio::spawn(async move { metrics::record_trade(&asset_t, sn_pm, m_name, sid, p_avg, o_bid, p_shares, pn, "Convergence/PairedExit".to_string()).await; });
+                                                    tokio::spawn(async move { metrics::record_trade(&asset_t, sn_pm, m_name, sid, p_avg, o_bid, p_shares, pn, "Convergence/PairedExit".to_string(), paired_ghost).await; });
                                                 }
                                                 {
                                                     let sn_cp = sn.clone(); let tid_cp = other_tid.to_string(); let asset_c = asset_lc.clone();
@@ -713,8 +929,10 @@ impl Squadron {
                                     }
                                     if reason.to_lowercase().contains("expir") { last_expiry_exit_time.insert(sn.clone(), Instant::now()); }
                                     last_trade_time.insert(sn.clone(), Instant::now());
-                                    { let tok = tg_token.clone(); let cid = tg_chat_id.clone(); let msg = format!("🔴 EXIT [{}] {} | bid=${:.4} | reason: {} | Session PnL: ${:.4}", sn, params.market_name, params.price, reason, *total_pnl.lock().await); tokio::spawn(async move { let _ = send_notification(&tok, &cid, &msg).await; }); }
-                                    { let session_pnl = *total_pnl.lock().await; tweet_trade(tw_api_key.clone(), tw_api_secret.clone(), tw_access_token.clone(), tw_access_token_secret.clone(), sn.clone(), params.market_name.clone(), re_m, params.price, reason.clone(), pnl_m + paired_pnl, session_pnl); }
+                                    // D8: notifications keep firing for ghost exits but are labeled 👻 [PAPER]
+                                    // and report the paper session P&L; live notifications are unchanged.
+                                    { let tok = tg_token.clone(); let cid = tg_chat_id.clone(); let session_pnl = if pos_ghost { *paper_pnl.lock().await } else { *total_pnl.lock().await }; let prefix = if pos_ghost { "👻 [PAPER] " } else { "" }; let msg = format!("{}🔴 EXIT [{}] {} | bid=${:.4} | reason: {} | Session PnL: ${:.4}", prefix, sn, params.market_name, params.price, reason, session_pnl); tokio::spawn(async move { let _ = send_notification(&tok, &cid, &msg).await; }); }
+                                    { let session_pnl = if pos_ghost { *paper_pnl.lock().await } else { *total_pnl.lock().await }; let tweet_market = if pos_ghost { format!("👻 [PAPER] {}", params.market_name) } else { params.market_name.clone() }; tweet_trade(tw_api_key.clone(), tw_api_secret.clone(), tw_access_token.clone(), tw_access_token_secret.clone(), sn.clone(), tweet_market, re_m, params.price, reason.clone(), pnl_m + paired_pnl, session_pnl); }
                                 }
                             }
 
@@ -830,29 +1048,66 @@ impl Squadron {
                                     if let Some(expiry) = pending.get(&pos_key) { if expiry > &Instant::now() { continue; } }
                                 }
 
-                                    if config::GHOST_MODE {
-                                    if positions.lock().await.contains_key(&pos_key) { continue; }
+                                    if params.ghost_mode {
+                                    {
+                                        // Guard BOTH legs: never overwrite an existing position
+                                        // (live OR ghost) for the primary or the paired token. A
+                                        // LIVE→GHOST toggle can leave a live pair leg in the map;
+                                        // unconditionally re-inserting the paired ghost leg (below)
+                                        // would silently convert that real exposure into paper.
+                                        let map = positions.lock().await;
+                                        if map.contains_key(&pos_key) { continue; }
+                                        if let Some(pp) = pair_params.as_ref() {
+                                            if map.contains_key(&(sn.clone(), pp.token_id.clone())) { continue; }
+                                        }
+                                    }
                                     let pos_close_time = target_market_close_time;
-                                    let actual_entry_price = if params.post_only { params.price } else { (params.price + config::BUY_PRICE_OFFSET).min(config::MAX_BUY_LIMIT_PRICE) };
-                                    positions.lock().await.insert(pos_key.clone(), Position { shares: params.shares, avg_entry: actual_entry_price, opened_at: Utc::now(), close_time: pos_close_time, market_name: params.market_name.clone(), pair_token_id: token_m.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: pair_params.as_ref().map(|p| p.token_id.clone()) });
+                                    // D4: depth-aware simulated taker entry fill. Up to ask_depth shares fill at
+                                    // the offset ask (current price logic); the overflow tranche fills worse
+                                    // (+PAPER_OVERFLOW_SLIPPAGE, capped at MAX_BUY_LIMIT_PRICE). post_only quotes
+                                    // rest, so they keep the requested price with no overflow.
+                                    let primary_base = if params.post_only { params.price } else { (params.price + config::BUY_PRICE_OFFSET).min(config::MAX_BUY_LIMIT_PRICE) };
+                                    let primary_ask_depth = if params.token_id == target_yes_token { entry_snap.yes_ask_depth } else { entry_snap.no_ask_depth };
+                                    let actual_entry_price = if params.post_only { primary_base } else {
+                                        crate::helpers::paper::simulate_taker_buy_avg(primary_base, primary_ask_depth, params.shares, config::PAPER_OVERFLOW_SLIPPAGE, config::MAX_BUY_LIMIT_PRICE)
+                                    };
+                                    // Paired leg fill price (if any) — computed up-front for the combined ledger check.
+                                    let paired_fill: Option<(Decimal, Decimal)> = pair_params.as_ref().map(|pp| {
+                                        let base = if pp.post_only { pp.price } else { (pp.price + config::BUY_PRICE_OFFSET).min(config::MAX_BUY_LIMIT_PRICE) };
+                                        let ask_depth = if pp.token_id == target_yes_token { entry_snap.yes_ask_depth } else { entry_snap.no_ask_depth };
+                                        let price = if pp.post_only { base } else {
+                                            crate::helpers::paper::simulate_taker_buy_avg(base, ask_depth, pp.shares, config::PAPER_OVERFLOW_SLIPPAGE, config::MAX_BUY_LIMIT_PRICE)
+                                        };
+                                        (price, pp.shares)
+                                    });
+                                    // D7: debit the paper collateral ledger; reject (warn + skip, no panic) when
+                                    // the ledger cannot cover the (combined) simulated cost.
+                                    let total_cost = actual_entry_price * params.shares
+                                        + paired_fill.map(|(pr, sh)| pr * sh).unwrap_or(dec!(0));
+                                    {
+                                        let mut bal = paper_balance.lock().await;
+                                        if *bal < total_cost {
+                                            warn!("👻 [PAPER] ENTRY REJECTED [{}]: {} | cost ${:.4} exceeds paper balance ${:.4} — skipping (simulated)", sn, params.market_name, total_cost, *bal);
+                                            last_trade_time.insert(sn.clone(), Instant::now());
+                                            continue;
+                                        }
+                                        *bal -= total_cost;
+                                    }
+                                    positions.lock().await.insert(pos_key.clone(), Position { shares: params.shares, avg_entry: actual_entry_price, opened_at: Utc::now(), close_time: pos_close_time, market_name: params.market_name.clone(), pair_token_id: token_m.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: pair_params.as_ref().map(|p| p.token_id.clone()), ghost: true });
                                     token_ownership.lock().await.insert(token_m.clone(), sn.clone());
                                     let side_g = if params.token_id == target_yes_token { "YES" } else { "NO" };
-                                    info!("👻 GHOST_MODE ENTRY {} [{}]: {} | ${:.4} x {:.1} (simulated)", side_g, sn, params.market_name, params.price, params.shares);
-                                    { let side_g = if params.token_id == target_yes_token { "YES" } else { "NO" }; let sn_g = sn.clone(); let tid_g = params.token_id.to_string(); let mn_g = params.market_name.clone(); let side_gs = side_g.to_string(); let ep_g = actual_entry_price; let sh_g = params.shares; let asset_g = asset_lc.clone(); tokio::spawn(async move { metrics::record_entry(&asset_g, sn_g, tid_g, mn_g, side_gs, ep_g, sh_g).await; }); }
+                                    info!("👻 [PAPER] ENTRY {} [{}]: {} | ${:.4} x {:.1} @ fill ${:.4} (simulated)", side_g, sn, params.market_name, params.price, params.shares, actual_entry_price);
+                                    { let side_g = if params.token_id == target_yes_token { "YES" } else { "NO" }; let sn_g = sn.clone(); let tid_g = params.token_id.to_string(); let mn_g = params.market_name.clone(); let side_gs = side_g.to_string(); let ep_g = actual_entry_price; let sh_g = params.shares; let asset_g = asset_lc.clone(); tokio::spawn(async move { metrics::record_entry(&asset_g, sn_g, tid_g, mn_g, side_gs, ep_g, sh_g, true).await; }); }
                                     { let side_g = if params.token_id == target_yes_token { "YES" } else { "NO" }; let sn_g = sn.clone(); let tid_g = params.token_id.to_string(); let mn_g = params.market_name.clone(); let side_gs = side_g.to_string(); let ep_g = actual_entry_price; let sh_g = params.shares; let asset_g = asset_lc.clone(); let snap_g = entry_snap.clone(); tokio::spawn(async move { metrics::record_entry_signal(&asset_g, sn_g, tid_g, mn_g, side_gs, ep_g, sh_g, &snap_g).await; }); }
                                     if let Some(pool) = db::pool_for(&asset_lc) { let side_g = if params.token_id == target_yes_token { "YES" } else { "NO" }; db::record_open_position(&pool, &sn, &params.token_id.to_string(), &params.market_name, side_g, actual_entry_price, params.shares, true).await; }
                                     if let Some(pp) = pair_params {
                                         let pp_close_time = target_market_close_time;
-                                        let actual_paired_entry_price = if pp.post_only {
-                                            pp.price
-                                        } else {
-                                            (pp.price + config::BUY_PRICE_OFFSET).min(config::MAX_BUY_LIMIT_PRICE)
-                                        };
-                                        positions.lock().await.insert((sn.clone(), pp.token_id.clone()), Position { shares: pp.shares, avg_entry: actual_paired_entry_price, opened_at: Utc::now(), close_time: pp_close_time, market_name: pp.market_name.clone(), pair_token_id: pp.token_id.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: Some(token_m.clone()) });
+                                        let actual_paired_entry_price = paired_fill.map(|(pr, _)| pr).unwrap_or(pp.price);
+                                        positions.lock().await.insert((sn.clone(), pp.token_id.clone()), Position { shares: pp.shares, avg_entry: actual_paired_entry_price, opened_at: Utc::now(), close_time: pp_close_time, market_name: pp.market_name.clone(), pair_token_id: pp.token_id.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: Some(token_m.clone()), ghost: true });
                                         token_ownership.lock().await.insert(pp.token_id.clone(), sn.clone());
                                         let side_gp = if pp.token_id == target_yes_token { "YES" } else { "NO" };
-                                        info!("👻 GHOST_MODE ENTRY {} (paired) [{}]: {} | ${:.4} x {:.1} (simulated)", side_gp, sn, pp.market_name, pp.price, pp.shares);
-                                        { let side_gp = if pp.token_id == target_yes_token { "YES" } else { "NO" }; let sn_gp = sn.clone(); let tid_gp = pp.token_id.to_string(); let mn_gp = pp.market_name.clone(); let side_gps = side_gp.to_string(); let ep_gp = actual_paired_entry_price; let sh_gp = pp.shares; let asset_gp = asset_lc.clone(); tokio::spawn(async move { metrics::record_entry(&asset_gp, sn_gp, tid_gp, mn_gp, side_gps, ep_gp, sh_gp).await; }); }
+                                        info!("👻 [PAPER] ENTRY {} (paired) [{}]: {} | ${:.4} x {:.1} @ fill ${:.4} (simulated)", side_gp, sn, pp.market_name, pp.price, pp.shares, actual_paired_entry_price);
+                                        { let side_gp = if pp.token_id == target_yes_token { "YES" } else { "NO" }; let sn_gp = sn.clone(); let tid_gp = pp.token_id.to_string(); let mn_gp = pp.market_name.clone(); let side_gps = side_gp.to_string(); let ep_gp = actual_paired_entry_price; let sh_gp = pp.shares; let asset_gp = asset_lc.clone(); tokio::spawn(async move { metrics::record_entry(&asset_gp, sn_gp, tid_gp, mn_gp, side_gps, ep_gp, sh_gp, true).await; }); }
                                         if let Some(pool) = db::pool_for(&asset_lc) { let side_gp = if pp.token_id == target_yes_token { "YES" } else { "NO" }; db::record_open_position(&pool, &sn, &pp.token_id.to_string(), &pp.market_name, side_gp, actual_paired_entry_price, pp.shares, true).await; }
                                     }
                                     last_trade_time.insert(sn.clone(), Instant::now());
@@ -861,7 +1116,7 @@ impl Squadron {
                                     {
                                         let mut map = positions.lock().await; if map.contains_key(&pos_key) { continue; }
                                         let pos_close_time = target_market_close_time;
-                                        map.insert(pos_key.clone(), Position { shares: params.shares, avg_entry: actual_entry_price, opened_at: Utc::now(), close_time: pos_close_time, market_name: params.market_name.clone(), pair_token_id: token_m.clone(), fill_confirmed_at: None, paired_leg_token_id: pair_params.as_ref().map(|p| p.token_id.clone()) });
+                                        map.insert(pos_key.clone(), Position { shares: params.shares, avg_entry: actual_entry_price, opened_at: Utc::now(), close_time: pos_close_time, market_name: params.market_name.clone(), pair_token_id: token_m.clone(), fill_confirmed_at: None, paired_leg_token_id: pair_params.as_ref().map(|p| p.token_id.clone()), ghost: false });
                                     }
                                     // Claim token in ownership registry immediately — prevents any
                                     // concurrent strategy tick from racing into the same token
@@ -942,12 +1197,12 @@ impl Squadron {
                                                         if let Some(pool) = db::pool_for(&asset_a) {
                                                             db::confirm_position_status(&pool, &db_sn_a, &db_tid_a).await;
                                                         }
-                                                        metrics::record_entry(&asset_a, db_sn_a, db_tid_a, db_mn_a, db_side_a.to_string(), db_ep_a, db_sh_a).await;
+                                                        metrics::record_entry(&asset_a, db_sn_a, db_tid_a, db_mn_a, db_side_a.to_string(), db_ep_a, db_sh_a, false).await;
                                                     }
                                                 });
 
                                         let pp_close_time = target_market_close_time;
-                                        positions.lock().await.insert((sn.clone(), pp_token_m.clone()), Position { shares: pp.shares, avg_entry: actual_pair_entry_price, opened_at: Utc::now(), close_time: pp_close_time, market_name: pp.market_name.clone(), pair_token_id: pp_token_m.clone(), fill_confirmed_at: None, paired_leg_token_id: Some(token_m.clone()) });
+                                        positions.lock().await.insert((sn.clone(), pp_token_m.clone()), Position { shares: pp.shares, avg_entry: actual_pair_entry_price, opened_at: Utc::now(), close_time: pp_close_time, market_name: pp.market_name.clone(), pair_token_id: pp_token_m.clone(), fill_confirmed_at: None, paired_leg_token_id: Some(token_m.clone()), ghost: false });
                                         // Claim paired token in registry.
                                         token_ownership.lock().await.insert(pp_token_m.clone(), sn.clone());
 
@@ -965,7 +1220,7 @@ impl Squadron {
                                                         if let Some(pool) = db::pool_for(&asset_b) {
                                                             db::confirm_position_status(&pool, &db_sn_b, &db_tid_b).await;
                                                         }
-                                                        metrics::record_entry(&asset_b, db_sn_b, db_tid_b, db_mn_b, db_side_b.to_string(), db_ep_b, db_sh_b).await;
+                                                        metrics::record_entry(&asset_b, db_sn_b, db_tid_b, db_mn_b, db_side_b.to_string(), db_ep_b, db_sh_b, false).await;
                                                     }
                                                 });
 
@@ -1048,7 +1303,7 @@ impl Squadron {
                                                 if let Some(pool) = db::pool_for(&asset_s) {
                                                     db::confirm_position_status(&pool, &db_sn_s, &db_tid_s).await;
                                                 }
-                                                metrics::record_entry(&asset_s, db_sn_s.clone(), db_tid_s.clone(), db_mn_s.clone(), db_side_s.to_string(), db_ep_s, db_sh_s).await;
+                                                metrics::record_entry(&asset_s, db_sn_s.clone(), db_tid_s.clone(), db_mn_s.clone(), db_side_s.to_string(), db_ep_s, db_sh_s, false).await;
                                                 metrics::record_entry_signal(&asset_s, db_sn_s, db_tid_s, db_mn_s, db_side_s.to_string(), db_ep_s, db_sh_s, &feat_snap_s).await;
                                             }
                                         });
@@ -1065,15 +1320,33 @@ impl Squadron {
                                     let p_token_m = p.token_id.clone(); // neutral key (slice 2a)
                                     let pk = (sn.clone(), p_token_m.clone());
                                     { let pending = pending_orders.lock().await; if let Some(expiry) = pending.get(&pk) { if expiry > &Instant::now() { continue; } } }
-                                    if config::GHOST_MODE {
+                                    if p.ghost_mode {
+                                        // D5: register a RESTING quote instead of an instant fill. It fills on a
+                                        // later tick once the market's best bid has sat at/below it long enough.
                                         if positions.lock().await.contains_key(&pk) { continue; }
-                                        positions.lock().await.insert(pk.clone(), Position { shares: p.shares, avg_entry: p.price, opened_at: Utc::now(), close_time: None, market_name: p.market_name.clone(), pair_token_id: p_token_m.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: None });
-                                        info!("👻 GHOST_MODE MakerQuote [{}]: {} | shares={:.2}, bid=${:.4} (simulated)", sn, p.market_name, p.shares, p.price);
+                                        let side_q = if p.token_id == target_yes_token { "YES" } else { "NO" }.to_string();
+                                        // A quote for the same (strategy, token) supersedes the previous one,
+                                        // but re-emitting the SAME price every qualifying tick must NOT reset
+                                        // the simulated queue position — otherwise the counter is pinned at 0/1
+                                        // and the quote can never rest PAPER_MAKER_FILL_TICKS ticks. Only a
+                                        // genuine price change re-joins the back of the queue (resets to 0).
+                                        let prev_ticks = ghost_maker_quotes.get(&pk)
+                                            .filter(|q| q.price == p.price)
+                                            .map(|q| q.consecutive_ticks)
+                                            .unwrap_or(0);
+                                        ghost_maker_quotes.insert(pk.clone(), GhostRestingQuote {
+                                            price: p.price,
+                                            shares: p.shares,
+                                            market_name: p.market_name.clone(),
+                                            side: side_q,
+                                            consecutive_ticks: prev_ticks,
+                                        });
+                                        info!("👻 [PAPER] MakerQuote resting [{}]: {} | shares={:.2}, bid=${:.4} (simulated queue)", sn, p.market_name, p.shares, p.price);
                                         placed = true;
                                     } else {
                                         if !positions.lock().await.contains_key(&pk) {
                                             info!("📝 MakerQuote [{}]: {} | shares={:.2}, bid=${:.4}", sn, p.market_name, p.shares, p.price);
-                                            positions.lock().await.insert(pk.clone(), Position { shares: p.shares, avg_entry: p.price, opened_at: Utc::now(), close_time: None, market_name: p.market_name.clone(), pair_token_id: p_token_m.clone(), fill_confirmed_at: None, paired_leg_token_id: None });
+                                            positions.lock().await.insert(pk.clone(), Position { shares: p.shares, avg_entry: p.price, opened_at: Utc::now(), close_time: None, market_name: p.market_name.clone(), pair_token_id: p_token_m.clone(), fill_confirmed_at: None, paired_leg_token_id: None, ghost: false });
                                             token_ownership.lock().await.insert(p_token_m.clone(), sn.clone());
                                             { pending_orders.lock().await.insert(pk.clone(), Instant::now() + Duration::from_secs(3)); }
                                             let _ = tokio::time::timeout(Duration::from_secs(10), crate::helpers::balance::quick_confirm_fill(&trading_client, &sn, &p.token_id, &positions, &p.condition_id, p.order_type.clone())).await;
@@ -1099,7 +1372,7 @@ impl Squadron {
                                                     if let Some(pool) = db::pool_for(&asset_em) {
                                                         db::confirm_position_status(&pool, &sn_m, &tid_em).await;
                                                     }
-                                                    metrics::record_entry(&asset_em, sn_m, tid_em, mn_em, side_em, ep_em, sh_em).await;
+                                                    metrics::record_entry(&asset_em, sn_m, tid_em, mn_em, side_em, ep_em, sh_em, false).await;
                                                 }
                                             });
                                         }
@@ -1116,6 +1389,73 @@ impl Squadron {
                     }).await;
                     if signal_processing_result.is_err() {
                         warn!("⚠️ Signal processing timed out (45s) — select! loop unblocked, watchdog/heartbeat resume");
+                    }
+
+                    // ── D5: advance & fill simulated resting ghost maker quotes ──────────
+                    // Runs every tick (independent of the signal-processing timeout above)
+                    // so resting quotes accrue queue time even on ticks that produced no
+                    // new signals. A quote fills once its best bid has been ≤ the quote
+                    // price for PAPER_MAKER_FILL_TICKS consecutive ticks.
+                    if !ghost_maker_quotes.is_empty() {
+                        // Map a token id to its current market best bid from this tick's raw feeds.
+                        let bid_for = |tok: &MarketId| -> Decimal {
+                            if *tok == hourly_yes_token { hourly_yb }
+                            else if *tok == hourly_no_token { hourly_nb }
+                            else if maker_market_config.as_ref().is_some_and(|mk| mk.yes_token == *tok) { maker_yb }
+                            else if maker_market_config.as_ref().is_some_and(|mk| mk.no_token == *tok) { maker_nb }
+                            else { dec!(0) }
+                        };
+                        let mut fills: Vec<((String, MarketId), GhostRestingQuote)> = Vec::new();
+                        ghost_maker_quotes.retain(|(qsn, qtok), q| {
+                            let best_bid = bid_for(qtok);
+                            q.consecutive_ticks = crate::helpers::paper::maker_next_tick_count(q.consecutive_ticks, best_bid, q.price);
+                            if crate::helpers::paper::maker_should_fill(q.consecutive_ticks, config::PAPER_MAKER_FILL_TICKS) {
+                                fills.push(((qsn.clone(), qtok.clone()), q.clone()));
+                                false // filled — drop from the resting registry
+                            } else {
+                                true
+                            }
+                        });
+                        for ((qsn, qtok), q) in fills {
+                            // Skip if a position already exists for this (strategy, token).
+                            if positions.lock().await.contains_key(&(qsn.clone(), qtok.clone())) { continue; }
+                            // Sovereignty: never fill a ghost quote onto a token another strategy
+                            // already owns or holds. A resting ghost quote claims no ownership, so a
+                            // live strategy can open a real position on the same token in the interim;
+                            // filling here would commingle a paper position with a live on-chain balance
+                            // and corrupt that strategy's live exit reconciliation (2026-06-27 Basis loss).
+                            {
+                                let owned_by_other = token_ownership.lock().await
+                                    .get(&qtok).map(|o| o != &qsn).unwrap_or(false);
+                                let held_by_other = positions.lock().await.iter()
+                                    .any(|((s, t), _)| *t == qtok && s != &qsn);
+                                if owned_by_other || held_by_other {
+                                    warn!("👻 [PAPER] MakerQuote fill SKIPPED [{}]: token {} owned/held by another strategy (simulated)", qsn, qtok);
+                                    continue;
+                                }
+                            }
+                            // D7 ledger debit — reject the simulated fill if the paper ledger can't cover it.
+                            let cost = q.price * q.shares;
+                            {
+                                let mut bal = paper_balance.lock().await;
+                                if *bal < cost {
+                                    warn!("👻 [PAPER] MakerQuote fill REJECTED [{}]: {} | cost ${:.4} exceeds paper balance ${:.4} (simulated)", qsn, q.market_name, cost, *bal);
+                                    continue;
+                                }
+                                *bal -= cost;
+                            }
+                            positions.lock().await.insert((qsn.clone(), qtok.clone()), Position { shares: q.shares, avg_entry: q.price, opened_at: Utc::now(), close_time: None, market_name: q.market_name.clone(), pair_token_id: qtok.clone(), fill_confirmed_at: Some(Utc::now()), paired_leg_token_id: None, ghost: true });
+                            token_ownership.lock().await.insert(qtok.clone(), qsn.clone());
+                            info!("👻 [PAPER] MakerQuote FILLED [{}]: {} | {:.2} shares @ ${:.4} after {} ticks (simulated)", qsn, q.market_name, q.shares, q.price, q.consecutive_ticks);
+                            // Same DB rows a live maker fill writes (entries + open_positions), ghost-flagged.
+                            if let Some(pool) = db::pool_for(&asset_lc) {
+                                db::record_open_position(&pool, &qsn, &qtok.to_string(), &q.market_name, &q.side, q.price, q.shares, true).await;
+                            }
+                            let asset_g = asset_lc.clone(); let tid_g = qtok.to_string(); let mn_g = q.market_name.clone(); let side_g = q.side.clone(); let ep_g = q.price; let sh_g = q.shares;
+                            tokio::spawn(async move {
+                                metrics::record_entry(&asset_g, qsn, tid_g, mn_g, side_g, ep_g, sh_g, true).await;
+                            });
+                        }
                     }
                 }
             }

--- a/src/squadron/patrol_tasks.rs
+++ b/src/squadron/patrol_tasks.rs
@@ -179,6 +179,12 @@ async fn calculate_positions_value(pool: &sqlx::SqlitePool) -> Decimal {
     let mut deduped_by_token: std::collections::HashMap<String, db::OpenPositionRow> =
         std::collections::HashMap::new();
     for pos in positions {
+        // D7: GHOST (paper) rows are segregated from the LIVE portfolio value / equity
+        // curve. Marking them into total_value would commingle simulated exposure with
+        // real wallet collateral in pnl_snapshots and the PnlChart.
+        if pos.ghost_mode {
+            continue;
+        }
         // Skip UNCONFIRMED phantoms: a row that is still `status='pending'` AND has
         // not been chain-adopted represents an order we placed but the chain never
         // confirmed (never filled, or rejected). Marking these to market for up to
@@ -248,6 +254,14 @@ pub fn spawn_status_task(
     cancel: CancellationToken,
 ) {
     tokio::spawn(async move {
+        // Heartbeat oracle label reflects the active market-data source. On
+        // Binance it stays the literal `Binance:` so tools/session_parser.py
+        // keeps parsing it; Hyperliquid deployments print `Oracle:` in the same
+        // numeric format. Resolved once per task (not per tick).
+        let oracle_label = match crate::raptors::source::MarketDataSource::resolve() {
+            crate::raptors::source::MarketDataSource::Binance => "Binance",
+            crate::raptors::source::MarketDataSource::Hyperliquid => "Oracle",
+        };
         let mut ticker = interval(Duration::from_secs(60));
         ticker.tick().await;
         loop {
@@ -273,8 +287,8 @@ pub fn spawn_status_task(
                     info!(
                         " Heartbeat | Ask Sum ${:.4} (Y ask ${:.2} / N ask ${:.2}) | \
                          Bid Sum ${:.4} (Y bid ${:.2} / N bid ${:.2}) | \
-                         Binance: ${:.2} | OBI Y={:.2} N={:.2}",
-                        ya + na, ya, na, yb + nb, yb, nb, *oracle_rx.borrow(), yes_obi, no_obi,
+                         {}: ${:.2} | OBI Y={:.2} N={:.2}",
+                        ya + na, ya, na, yb + nb, yb, nb, oracle_label, *oracle_rx.borrow(), yes_obi, no_obi,
                     );
 
                     // Refresh live pUSD balance so strategies can self-gate on insufficient funds.
@@ -346,6 +360,11 @@ pub fn spawn_cleanup_task(
     tg_token:             String,
     tg_chat_id:           String,
     asset:                String,
+    // D6/D7: paper settlement + segregated ledger inputs.
+    oracle_rx:            watch::Receiver<Decimal>,
+    hourly_strike_price:  Option<Decimal>,
+    paper_pnl:            Arc<Mutex<Decimal>>,
+    paper_balance:        Arc<Mutex<Decimal>>,
     cancel:               CancellationToken,
 ) {
     tokio::spawn(async move {
@@ -360,12 +379,19 @@ pub fn spawn_cleanup_task(
                     // Returns the list of confirmed-fill orphans so we can attempt FAK sells
                     // OUTSIDE the timeout — sell latency does not count against the 45 s cap.
                     let orphan_exits = match tokio::time::timeout(Duration::from_secs(45), async {
+                        let oracle_now = *oracle_rx.borrow();
                         if hourly_yes_token != crate::venues::intl::market_id_from_u256(U256::ZERO) {
                             crate::tasks::cleanup::cleanup_expired_positions(
                                 Arc::clone(&positions),
                                 hourly_market_name.clone(),
                                 hourly_yes_token.clone(), hourly_no_token.clone(),
                                 hourly_market_close_time,
+                                hourly_strike_price,
+                                oracle_now,
+                                Arc::clone(&paper_pnl),
+                                Arc::clone(&paper_balance),
+                                asset.clone(),
+                                false,
                             ).await;
                         }
                         if let Some(ref mk) = maker_market_config {
@@ -374,6 +400,12 @@ pub fn spawn_cleanup_task(
                                 mk.market_name.clone(),
                                 mk.yes_token.clone(), mk.no_token.clone(),
                                 mk.market_close_time,
+                                mk.strike_price,
+                                oracle_now,
+                                Arc::clone(&paper_pnl),
+                                Arc::clone(&paper_balance),
+                                asset.clone(),
+                                false,
                             ).await;
                         }
 
@@ -410,9 +442,55 @@ pub fn spawn_cleanup_task(
                     // Priority 1 — RE-HEDGE: buy the MISSING leg at its current ask (FAK).
                     // Priority 2 — BID-BASED EXIT: sell the orphan at (current_bid − offset).
                     //
-                    // GHOST_MODE guard: neither path places live orders in ghost mode.
-                    if !config::GHOST_MODE {
+                    // Position-scoped: ghost (paper) legs get a simulated bid-priced close;
+                    // live legs get the unchanged re-hedge / FAK-sell logic below.
+                    {
                         for orphan in orphan_exits {
+                            // GHOST (paper) orphan: close via a simulated bid-priced exit (D4/D7)
+                            // instead of a live re-hedge/FAK-sell, then record + close the DB row.
+                            if orphan.ghost {
+                                let maker_yes_match = maker_market_config.as_ref().is_some_and(|mkc| mkc.yes_token == orphan.token_id);
+                                let maker_no_match = maker_market_config.as_ref().is_some_and(|mkc| mkc.no_token == orphan.token_id);
+                                let (orphan_bid, orphan_bid_depth) = if orphan.token_id == hourly_yes_token {
+                                    let (b, bd, _, _, _) = *yes_price_rx.borrow(); (b, bd)
+                                } else if orphan.token_id == hourly_no_token {
+                                    let (b, bd, _, _, _) = *no_price_rx.borrow(); (b, bd)
+                                } else if let (true, Some(rx)) = (maker_yes_match, maker_yes_price_rx.as_ref()) {
+                                    let (b, bd, _, _, _) = *rx.borrow(); (b, bd)
+                                } else if let (true, Some(rx)) = (maker_no_match, maker_no_price_rx.as_ref()) {
+                                    let (b, bd, _, _, _) = *rx.borrow(); (b, bd)
+                                } else { (dec!(0), dec!(0)) };
+                                let base = if orphan_bid > dec!(0) {
+                                    (orphan_bid - config::SELL_PRICE_OFFSET).max(config::MIN_SELL_LIMIT_PRICE)
+                                } else {
+                                    config::MIN_SELL_LIMIT_PRICE
+                                };
+                                let exit_avg = crate::helpers::paper::simulate_taker_sell_avg(
+                                    base, orphan_bid_depth, orphan.shares,
+                                    config::PAPER_OVERFLOW_SLIPPAGE, config::MIN_SELL_LIMIT_PRICE,
+                                );
+                                let pnl = (exit_avg - orphan.original_entry) * orphan.shares;
+                                *paper_pnl.lock().await += pnl;
+                                *paper_balance.lock().await += exit_avg * orphan.shares;
+                                let side = if orphan.token_id == hourly_yes_token
+                                    || maker_market_config.as_ref().is_some_and(|mkc| mkc.yes_token == orphan.token_id) { "YES" } else { "NO" };
+                                let market = if orphan.token_id == hourly_yes_token || orphan.token_id == hourly_no_token {
+                                    hourly_market_name.clone()
+                                } else {
+                                    maker_market_config.as_ref().map(|mkc| mkc.market_name.clone()).unwrap_or_else(|| hourly_market_name.clone())
+                                };
+                                warn!("👻 [PAPER] ORPHAN CLOSE [{}]: {:.2} shares of token {} @ ${:.4} (simulated bid exit) pnl=${:.4}",
+                                      orphan.strategy, orphan.shares, orphan.token_id, exit_avg, pnl);
+                                metrics::record_trade(
+                                    &asset, orphan.strategy.clone(), market, side.to_string(),
+                                    orphan.original_entry, exit_avg, orphan.shares, pnl,
+                                    "Orphan close (paper bid exit)".to_string(), true,
+                                ).await;
+                                if let Some(pool) = db::pool_for(&asset) {
+                                    db::close_open_position(&pool, &orphan.strategy, &orphan.token_id.to_string()).await;
+                                }
+                                continue;
+                            }
                             // Slice 2b: OrphanExit and market tokens are all neutral MarketId.
                             let vc = if orphan.is_neg_risk { EXCHANGE_NEG_RISK } else { EXCHANGE_NORMAL };
                             let mut rehedged = false;
@@ -549,6 +627,7 @@ pub fn spawn_cleanup_task(
                                                                         "ArbitrageStrategy".to_string(),
                                                                         rh_tid.clone(), rh_mkt.clone(), rh_sd.clone(),
                                                                         rh_ep, rh_sh,
+                                                                        false,
                                                                     ).await;
                                                                 } else {
                                                                     warn!("⚠️ ORPHAN RE-HEDGE: FAK order accepted but fill not confirmed on-chain — removing pending position");
@@ -749,6 +828,7 @@ pub fn spawn_lifecycle_task(
                                 shares,
                                 pnl,
                                 "LifecycleFlatten".to_string(),
+                                false,
                             ).await;
                         });
                     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -60,6 +60,11 @@ pub struct Position {
     /// If Some, this position is part of a hedged pair. Used to detect orphaned positions
     /// when the paired leg fails to fill.
     pub paired_leg_token_id: Option<MarketId>,
+    /// True when this position was opened in paper (ghost) mode. Position-scoped and
+    /// permanent: exits, reconciliation, orphan sweeps, and expiry settlement all key
+    /// off this flag — NOT the current GHOST/LIVE toggle — so a mid-session flip
+    /// grandfathers open positions (they close out under the mode they opened in).
+    pub ghost: bool,
 }
 
 /// Compound key for the shared position map: (strategy_name, token_id).

--- a/src/tasks/cleanup.rs
+++ b/src/tasks/cleanup.rs
@@ -217,36 +217,118 @@ async fn execute_via_safe<P: Provider + Clone>(
 }
 
 /// Remove all positions for a market that has expired or is expiring within 60s.
+///
+/// D6: before dropping expired positions, GHOST positions are settled at their binary
+/// payout ($1 if the market resolved in the token's favour, else $0) judged from the
+/// last known oracle price vs the market strike, booking realized paper P&L and the
+/// paper collateral credit and recording the settlement trade. LIVE positions keep the
+/// prior behaviour exactly — silently dropped here; on-chain settlement is owned by
+/// `auto_settle_closed_positions`.
+#[allow(clippy::too_many_arguments)]
 pub async fn cleanup_expired_positions(
     positions: Arc<Mutex<PositionMap>>,
     market_name: String,
     yes_token: MarketId,
     no_token: MarketId,
     close_time: Option<DateTime<Utc>>,
+    strike_price: Option<Decimal>,
+    oracle_price: Decimal,
+    paper_pnl: Arc<Mutex<Decimal>>,
+    paper_balance: Arc<Mutex<Decimal>>,
+    asset: String,
+    // When true (market-rotation teardown), settle & drop ghost legs regardless of the
+    // 60s close window and touch ONLY ghost positions (live legs are left in the map,
+    // grandfathered / settled on-chain). When false, the normal window-gated behaviour
+    // that also drops expired live positions is preserved exactly.
+    force: bool,
 ) {
-    let mut pos_map = positions.lock().await;
     let now = Utc::now();
 
     // Slice 2b: positions are keyed by the neutral MarketId directly.
     let yes_market = yes_token;
     let no_market = no_token;
 
-    if let Some(ct) = close_time {
-        let is_expired = ct <= now;
-        let is_expiring_soon = (ct - now).num_seconds() < 60;
+    // Ghost settlements collected while the map lock is held, then booked after it is
+    // released (record_trade/close_open_position are async DB writes).
+    struct GhostSettlement {
+        strategy: String,
+        token: MarketId,
+        side: &'static str,
+        avg_entry: Decimal,
+        shares: Decimal,
+        payout: Decimal,
+    }
+    let mut ghost_settlements: Vec<GhostSettlement> = Vec::new();
 
-        if is_expired || is_expiring_soon {
-            let before = pos_map.len();
-            pos_map.retain(|(_, token), _| token != &yes_market && token != &no_market);
-            let removed = before - pos_map.len();
+    {
+        let mut pos_map = positions.lock().await;
 
-            if removed > 0 {
-                warn!(" Cleaned up {} position(s) for market \"{}\" (expires {})",
-                    removed,
-                    market_name,
-                    if is_expired { "NOW" } else { "in <60s" }
-                );
+        if let Some(ct) = close_time {
+            let is_expired = ct <= now;
+            let is_expiring_soon = (ct - now).num_seconds() < 60;
+
+            if force || is_expired || is_expiring_soon {
+                // Settle ghost positions at binary payout before the retain drops them.
+                for ((strategy, token), pos) in pos_map.iter() {
+                    if (token != &yes_market && token != &no_market) || !pos.ghost {
+                        continue;
+                    }
+                    let is_yes = token == &yes_market;
+                    let payout = crate::helpers::paper::binary_settlement_payout(is_yes, oracle_price, strike_price);
+                    ghost_settlements.push(GhostSettlement {
+                        strategy: strategy.clone(),
+                        token: token.clone(),
+                        side: if is_yes { "YES" } else { "NO" },
+                        avg_entry: pos.avg_entry,
+                        shares: pos.shares,
+                        payout,
+                    });
+                }
+
+                let before = pos_map.len();
+                if force {
+                    // Rotation teardown: drop ONLY the ghost legs for this market; live
+                    // positions stay in the shared map (on-chain settlement owns them).
+                    pos_map.retain(|(_, token), pos| {
+                        !((token == &yes_market || token == &no_market) && pos.ghost)
+                    });
+                } else {
+                    pos_map.retain(|(_, token), _| token != &yes_market && token != &no_market);
+                }
+                let removed = before - pos_map.len();
+
+                if removed > 0 {
+                    warn!(" Cleaned up {} position(s) for market \"{}\" (expires {})",
+                        removed,
+                        market_name,
+                        if force { "rotation" } else if is_expired { "NOW" } else { "in <60s" }
+                    );
+                }
             }
+        }
+    }
+
+    // Book paper P&L + collateral and record settlement trades for the ghost legs.
+    for s in ghost_settlements {
+        let pnl = (s.payout - s.avg_entry) * s.shares;
+        *paper_pnl.lock().await += pnl;
+        *paper_balance.lock().await += s.payout * s.shares;
+        info!("👻 [PAPER] EXPIRY SETTLEMENT [{}]: {} {} | {:.2} shares @ entry ${:.4} → payout ${:.2} → pnl ${:.4} (simulated)",
+              s.strategy, market_name, s.side, s.shares, s.avg_entry, s.payout, pnl);
+        crate::helpers::metrics::record_trade(
+            &asset,
+            s.strategy.clone(),
+            market_name.clone(),
+            s.side.to_string(),
+            s.avg_entry,
+            s.payout,
+            s.shares,
+            pnl,
+            "expiry_settlement_sim".to_string(),
+            true,
+        ).await;
+        if let Some(pool) = db::pool_for(&asset) {
+            db::close_open_position(&pool, &s.strategy, &s.token.to_string()).await;
         }
     }
 }
@@ -292,6 +374,13 @@ pub struct OrphanExit {
     ///   re_hedge_cost = paired_ask + original_entry
     /// If re_hedge_cost < RE_HEDGE_THRESHOLD the arb is still profitable.
     pub original_entry: Decimal,
+    /// True when the orphaned leg was opened in paper (ghost) mode. Ghost orphans
+    /// are closed via a simulated bid-priced exit in the cleanup task rather than a
+    /// live re-hedge/FAK-sell.
+    pub ghost: bool,
+    /// Strategy that owns the orphaned leg — needed to record/close the simulated
+    /// ghost exit against the correct (strategy, token) DB row.
+    pub strategy: String,
 }
 
 pub async fn reconcile_orphaned_positions(
@@ -451,6 +540,8 @@ pub async fn reconcile_orphaned_positions(
                 is_neg_risk: false, // ArbitrageStrategy only runs on standard binary markets
                 paired_token_id: position.paired_leg_token_id,
                 original_entry: position.avg_entry,
+                ghost: position.ghost,
+                strategy: strategy_name.clone(),
             });
         }
     }
@@ -494,6 +585,8 @@ pub async fn reconcile_orphaned_positions(
                 is_neg_risk: false,
                 paired_token_id: None, // force flatten-only (no re-hedge atop existing opposite leg)
                 original_entry: position.avg_entry,
+                ghost: position.ghost,
+                strategy: strategy_name.clone(),
             });
         }
     }

--- a/src/venues/lifecycle.rs
+++ b/src/venues/lifecycle.rs
@@ -211,7 +211,11 @@ impl OrderLifecycle {
                     let i_held          = held.get(t.as_str()).copied().unwrap_or_default() > Decimal::ZERO;
                     let partner_held    = held.get(partner.as_str()).copied().unwrap_or_default() > Decimal::ZERO;
                     let partner_resting = resting_tokens.contains(partner.as_str());
-                    if p.fill_confirmed_at.is_some() && i_held && !partner_held && !partner_resting {
+                    // GHOST (paper) positions must never drive a REAL on-chain flatten:
+                    // their `held` truth comes from the wallet's token-keyed balance, which
+                    // can be satisfied by unrelated real shares, so a ghost leg could sell
+                    // real tokens it never bought. Live legs (ghost = false) are unaffected.
+                    if !p.ghost && p.fill_confirmed_at.is_some() && i_held && !partner_held && !partner_resting {
                         Some((s.clone(), t.clone(), p.shares, p.market_name.clone(), p.avg_entry))
                     } else {
                         None

--- a/src/venues/us/trader.rs
+++ b/src/venues/us/trader.rs
@@ -419,6 +419,7 @@ async fn trade_one_market(
                             shares,
                             pnl,
                             "LifecycleFlatten".to_string(),
+                            false,
                         ).await;
                     });
                 }
@@ -475,6 +476,11 @@ async fn trade_one_market(
             available_collateral,
             dynamic_config: dyn_cfg.clone(),
             arb_market_lockouts: None,
+            // Clock seam (W1): one consistent now per tick for all viper gates.
+            wall_now: Utc::now(),
+            mono_now: std::time::Instant::now(),
+            // Live trader — never a replay; vipers may consult live DB state.
+            is_replay: false,
         };
 
         // Evaluate the resolved vipers and dispatch whatever they decide.
@@ -595,6 +601,7 @@ async fn record_guard(
             pair_token_id: params.token_id.clone(),
             fill_confirmed_at: None,
             paired_leg_token_id: paired.cloned(),
+            ghost: params.ghost_mode,
         },
     );
 }

--- a/src/vipers/basis_impl.rs
+++ b/src/vipers/basis_impl.rs
@@ -20,7 +20,6 @@ use async_trait::async_trait;
 use anyhow::Result;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use chrono::Utc;
 
 use crate::orchestrator::{Strategy, StrategyContext};
 use crate::state::{StrategySignal, StrategyStatus, OrderParams};
@@ -52,7 +51,7 @@ impl Strategy for BasisStrategyImpl {
 
         // ── Expiry guard ─────────────────────────────────────────────────────
         if let Some(close_time) = market.market_close_time {
-            let secs_left = (close_time - Utc::now()).num_seconds();
+            let secs_left = (close_time - ctx.wall_now).num_seconds();
             if secs_left < config::BASIS_MIN_SECS_TO_EXPIRY {
                 return Ok(StrategySignal::NoSignal);
             }
@@ -62,7 +61,7 @@ impl Strategy for BasisStrategyImpl {
         // Stale snapshot depth/price values can let OBI and mid-price gates pass
         // silently when the actual live book has moved adversely.
         // GBoost and TimeDecay both gate on snapshot age; same protection here.
-        let snap_age = (Utc::now() - snap.timestamp).num_seconds();
+        let snap_age = (ctx.wall_now - snap.timestamp).num_seconds();
         if snap_age > config::BASIS_MAX_SNAPSHOT_AGE_SECS {
             return Ok(StrategySignal::NoSignal);
         }
@@ -306,7 +305,7 @@ impl Strategy for BasisStrategyImpl {
             if avg_entry <= dec!(0) { continue; }
 
             let profit_margin = (position_bid - avg_entry) / avg_entry;
-            let now = Utc::now();
+            let now = ctx.wall_now;
             let secs_held = (now - position.opened_at).num_seconds();
 
             // Recompute current YES mid to detect skew-collapse
@@ -393,7 +392,7 @@ impl Strategy for BasisStrategyImpl {
             }
 
             if let Some(close_time) = position.close_time {
-                let secs_left = (close_time - Utc::now()).num_seconds();
+                let secs_left = (close_time - ctx.wall_now).num_seconds();
                 if secs_left < config::BASIS_MIN_SECS_TO_EXPIRY / 2 {
                     // Skip BasisExpiry if the bid is too thin to get a FAK fill — near market
                     // close the order book dries up and FAK returns 0 fills while the position

--- a/src/vipers/convergence_impl.rs
+++ b/src/vipers/convergence_impl.rs
@@ -35,7 +35,6 @@ use rust_decimal_macros::dec;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Instant;
-use chrono::Utc;
 use tracing::debug;
 
 use crate::orchestrator::{Strategy, StrategyContext};
@@ -66,12 +65,15 @@ impl ConvergenceStrategyImpl {
         ctx.crypto_filter.eq_ignore_ascii_case("btc")
     }
 
-    fn record_exit(&self, token_id: &MarketId) {
+    fn record_exit(&self, token_id: &MarketId, mono_now: Instant) {
+        // Clock seam (W1): stamp cooldowns with the tick's monotonic now so the
+        // later `duration_since(mono_now)` comparison measures historical elapsed
+        // time under replay (behaviour-identical in production).
         if let Ok(mut map) = self.post_exit_cooldown.lock() {
-            map.insert(token_id.clone(), Instant::now());
+            map.insert(token_id.clone(), mono_now);
         }
         if let Ok(mut last) = self.last_exit_signal_at.lock() {
-            *last = Some(Instant::now());
+            *last = Some(mono_now);
         }
     }
 }
@@ -97,7 +99,7 @@ impl Strategy for ConvergenceStrategyImpl {
             return Ok(StrategySignal::NoSignal);
         }
         // Market maturation — avoid the thin, noisy book at market open.
-        let secs_since_start = (Utc::now() - ctx.market_started_at).num_seconds();
+        let secs_since_start = (ctx.wall_now - ctx.market_started_at).num_seconds();
         if secs_since_start < config::CONVERGENCE_MARKET_WARMUP_SECS {
             return Ok(StrategySignal::NoSignal);
         }
@@ -210,7 +212,7 @@ impl Strategy for ConvergenceStrategyImpl {
         // ── Per-token cooldown ────────────────────────────────────────────────
         if let Ok(map) = self.post_exit_cooldown.lock() {
             if let Some(t) = map.get(&token_id) {
-                if t.elapsed().as_secs() < config::CONVERGENCE_POST_EXIT_COOLDOWN_SECS {
+                if ctx.mono_now.duration_since(*t).as_secs() < config::CONVERGENCE_POST_EXIT_COOLDOWN_SECS {
                     return Ok(StrategySignal::NoSignal);
                 }
             }
@@ -239,7 +241,7 @@ impl Strategy for ConvergenceStrategyImpl {
         // or our position larger than the resting depth on our future-exit bid.
         let intended_shares = size / ask;
         let exit_bid_depth = if want_bull { snap.yes_bid_depth } else { snap.no_bid_depth };
-        let secs_left = market.market_close_time.map(|ct| (ct - Utc::now()).num_seconds());
+        let secs_left = market.market_close_time.map(|ct| (ct - ctx.wall_now).num_seconds());
         if let Some(reason) = crate::vipers::entry_liquidity_gate(secs_left, intended_shares, exit_bid_depth) {
             debug!(" Convergence blocked: {}", reason);
             return Ok(StrategySignal::NoSignal);
@@ -286,7 +288,7 @@ impl Strategy for ConvergenceStrategyImpl {
         let soft_exit_cooldown_active = {
             let last = self.last_exit_signal_at.lock().unwrap();
             match *last {
-                Some(t) => t.elapsed().as_secs() < config::CONVERGENCE_EXIT_SIGNAL_COOLDOWN_SECS,
+                Some(t) => ctx.mono_now.duration_since(t).as_secs() < config::CONVERGENCE_EXIT_SIGNAL_COOLDOWN_SECS,
                 None => false,
             }
         };
@@ -324,7 +326,7 @@ impl Strategy for ConvergenceStrategyImpl {
                 if avg_entry <= dec!(0) { continue; }
 
                 let fee_bps = if is_yes { market.yes_fee_bps as u16 } else { market.no_fee_bps as u16 };
-                let secs_held = (Utc::now() - position.opened_at).num_seconds();
+                let secs_held = (ctx.wall_now - position.opened_at).num_seconds();
                 let profit_margin = (bid - avg_entry) / avg_entry;
 
                 let make_exit = |reason: String| PendingExit {
@@ -396,7 +398,7 @@ impl Strategy for ConvergenceStrategyImpl {
         };
 
         if let Some(p) = pending {
-            self.record_exit(&p.token_id);
+            self.record_exit(&p.token_id, ctx.mono_now);
             return Ok(StrategySignal::Exit {
                 params: OrderParams {
                     token_id:     p.token_id,

--- a/src/vipers/gboost_impl.rs
+++ b/src/vipers/gboost_impl.rs
@@ -80,7 +80,7 @@ use std::collections::{VecDeque, HashMap}; // Added HashMap
 use std::sync::{Arc, Mutex as StdMutex};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use perpetual::{Matrix, PerpetualBooster};
 use perpetual::objective::Objective;
 use perpetual::booster::config::BoosterIO;
@@ -575,17 +575,22 @@ impl GboostStrategyImpl {
     ///      sparse.  Label: yes_bid rises within GBOOST_LOOKAHEAD_TICKS ticks → 1.0.
     ///      This breaks the chicken-and-egg deadlock that prevents the model from ever
     ///      reaching the minimum sample count required to produce its first predictions.
-    fn maybe_retrain(&self) {
+    fn maybe_retrain(&self, now: Instant) {
         if self.is_training.load(Ordering::Relaxed) { return; }
 
         // ── Degenerate-retrain backoff ─────────────────────────────────────────
         // When consecutive retrains produce degenerate models the engine must not
         // spin at 10-second intervals burning CPU.  Backoff grows exponentially:
         // 1st degen → 20s, 2nd → 40s, 3rd → 80s, … capped at 300s (5 min).
+        //
+        // `now` is the caller's clock (`ctx.mono_now` — the W1 seam), so under backtest
+        // replay the backoff is measured in HISTORICAL time (advancing 60s per candle),
+        // not real seconds; in production `ctx.mono_now` is `Instant::now()` captured at
+        // snapshot build, so behavior is unchanged.
         {
             let guard = self.retrain_backoff_until.lock().unwrap();
             if let Some(until) = *guard {
-                if Instant::now() < until {
+                if now < until {
                     return;
                 }
             }
@@ -717,8 +722,11 @@ impl GboostStrategyImpl {
                         let mut count = consecutive_degenerate.lock().unwrap();
                         *count += 1;
                         let backoff_secs = (20u64 * 2u64.pow((*count).saturating_sub(1).min(4) as u32)).min(300);
+                        // Deadline is relative to the caller's clock captured at spawn time
+                        // (`now` = `ctx.mono_now`), so replay measures the backoff in
+                        // historical time; identical to real time in production.
                         *retrain_backoff_until.lock().unwrap() =
-                            Some(Instant::now() + std::time::Duration::from_secs(backoff_secs));
+                            Some(now + std::time::Duration::from_secs(backoff_secs));
                         tracing::warn!(
                             " GboostStrategy: retrain produced degenerate model ({} trees < min {}), keeping previous (backoff {}s, #{} consecutive)",
                             n, config::GBOOST_MIN_USABLE_TREES, backoff_secs, *count
@@ -868,9 +876,9 @@ impl GboostStrategyImpl {
     }
 
     /// Mark token as cooling down with the standard cooldown after a TP or SignalRev exit.
-    fn mark_post_exit_cooldown(&self, token_id: MarketId) {
+    fn mark_post_exit_cooldown(&self, token_id: MarketId, wall_now: DateTime<Utc>) {
         let mut guard = self.post_exit_cooldowns.lock().unwrap();
-        guard.insert(token_id, (Utc::now(), config::GBOOST_POST_EXIT_COOLDOWN_SECS));
+        guard.insert(token_id, (wall_now, config::GBOOST_POST_EXIT_COOLDOWN_SECS));
     }
 
     /// Mark token as cooling down with the **extended** cooldown after a stop-loss exit.
@@ -878,14 +886,14 @@ impl GboostStrategyImpl {
     /// An SL exit means the market moved adversely against the position — not just that the
     /// model changed direction.  Using a longer cooldown (GBOOST_SL_POST_EXIT_COOLDOWN_SECS)
     /// prevents re-entering the same adverse direction within 20 minutes of a loss.
-    fn mark_post_exit_cooldown_sl(&self, token_id: MarketId) {
+    fn mark_post_exit_cooldown_sl(&self, token_id: MarketId, wall_now: DateTime<Utc>) {
         let mut guard = self.post_exit_cooldowns.lock().unwrap();
-        guard.insert(token_id, (Utc::now(), config::GBOOST_SL_POST_EXIT_COOLDOWN_SECS));
+        guard.insert(token_id, (wall_now, config::GBOOST_SL_POST_EXIT_COOLDOWN_SECS));
     }
 
     /// Returns remaining cooldown seconds for this token, if still cooling down.
-    fn post_exit_cooldown_remaining_secs(&self, token_id: MarketId) -> Option<i64> {
-        let now = Utc::now();
+    fn post_exit_cooldown_remaining_secs(&self, token_id: MarketId, wall_now: DateTime<Utc>) -> Option<i64> {
+        let now = wall_now;
         let mut guard = self.post_exit_cooldowns.lock().unwrap();
         if let Some((ts, cooldown_secs)) = guard.get(&token_id).copied() {
             let elapsed = (now - ts).num_seconds();
@@ -1010,7 +1018,7 @@ impl Strategy for GboostStrategyImpl {
             ctx.snapshot.clone()
         };
         self.push_snapshot(training_snapshot);
-        self.maybe_retrain();
+        self.maybe_retrain(ctx.mono_now);
 
         let dc = &ctx.dynamic_config;
         if !dc.enable_gboost {
@@ -1021,7 +1029,7 @@ impl Strategy for GboostStrategyImpl {
         }
 
         // ── Gate: market must be mature enough for orderbook features to be stable ──
-        if (Utc::now() - ctx.market_started_at).num_seconds() < config::GBOOST_MIN_MARKET_AGE_SECS {
+        if (ctx.wall_now - ctx.market_started_at).num_seconds() < config::GBOOST_MIN_MARKET_AGE_SECS {
             return Ok(StrategySignal::NoSignal);
         }
 
@@ -1150,7 +1158,7 @@ impl Strategy for GboostStrategyImpl {
         // live book has moved adversely between WebSocket events.
         // 2026-05-07 T6 & T7: entry_hb_age_sec 16–35s; live snapshot OBI differed
         // from heartbeat OBI by > 0.50, causing adverse entries.
-        let target_snap_age = (chrono::Utc::now() - target_snapshot.timestamp).num_seconds();
+        let target_snap_age = (ctx.wall_now - target_snapshot.timestamp).num_seconds();
         if target_snap_age > config::GBOOST_MAX_SNAPSHOT_AGE_SECS {
             tracing::debug!(
                 " GBoost entry blocked: target snapshot too stale ({}s > max {}s)",
@@ -1160,7 +1168,7 @@ impl Strategy for GboostStrategyImpl {
         }
         // Also gate on hourly snapshot staleness when trading the daily market.
         if ctx.maker_snapshot.is_some() {
-            let hourly_snap_age = (chrono::Utc::now() - ctx.snapshot.timestamp).num_seconds();
+            let hourly_snap_age = (ctx.wall_now - ctx.snapshot.timestamp).num_seconds();
             if hourly_snap_age > config::GBOOST_MAX_SNAPSHOT_AGE_SECS {
                 tracing::debug!(
                     " GBoost entry blocked: hourly snapshot too stale ({}s > max {}s)",
@@ -1171,7 +1179,7 @@ impl Strategy for GboostStrategyImpl {
         }
 
         if let Some(close_time) = target_market.market_close_time {
-            if (close_time - Utc::now()).num_seconds() < config::GBOOST_MIN_SECS_TO_EXPIRY {
+            if (close_time - ctx.wall_now).num_seconds() < config::GBOOST_MIN_SECS_TO_EXPIRY {
                 return Ok(StrategySignal::NoSignal);
             }
         }
@@ -1198,9 +1206,9 @@ impl Strategy for GboostStrategyImpl {
         {
             let conviction = (p_yes_up - 0.5).abs() * 2.0; // 0.0 at coin-flip, 1.0 at certainty
             let mut last = self.last_pred_log_at.lock().unwrap();
-            let due = last.map_or(true, |t| t.elapsed().as_secs() >= config::GBOOST_PRED_LOG_INTERVAL_SECS);
+            let due = last.map_or(true, |t| ctx.mono_now.duration_since(t).as_secs() >= config::GBOOST_PRED_LOG_INTERVAL_SECS);
             if due {
-                *last = Some(Instant::now());
+                *last = Some(ctx.mono_now);
                 tracing::info!(
                     " GboostStrategy: P(UP)={:.3} conviction={:.2} thr={:.2} {}",
                     p_yes_up, conviction, entry_thresh,
@@ -1217,9 +1225,9 @@ impl Strategy for GboostStrategyImpl {
             ($reason:expr) => {{
                 if entry_eligible {
                     let mut last = self.last_veto_log_at.lock().unwrap();
-                    let due = last.map_or(true, |t| t.elapsed().as_secs() >= config::GBOOST_PRED_LOG_INTERVAL_SECS);
+                    let due = last.map_or(true, |t| ctx.mono_now.duration_since(t).as_secs() >= config::GBOOST_PRED_LOG_INTERVAL_SECS);
                     if due {
-                        *last = Some(Instant::now());
+                        *last = Some(ctx.mono_now);
                         tracing::info!(" GBoost eligible-but-VETOED [{}] | P(UP)={:.3}", $reason, p_yes_up);
                     }
                 }
@@ -1289,13 +1297,13 @@ impl Strategy for GboostStrategyImpl {
                 if oracle_price < threshold {
                     // Spot is below the buffer — start or continue the timer
                     if bss.is_none() {
-                        *bss = Some(Instant::now());
+                        *bss = Some(ctx.mono_now);
                         tracing::debug!(
                             " GBoost: BTC spot ${:.0} < strike(${:.0}) − buffer(${:.0}) = ${:.0} — starting below-strike timer",
                             oracle_price, strike, buffer, threshold
                         );
                     }
-                    let elapsed_secs = bss.unwrap().elapsed().as_secs() as i64;
+                    let elapsed_secs = ctx.mono_now.duration_since(bss.unwrap()).as_secs() as i64;
                     elapsed_secs >= config::GBOOST_BELOW_STRIKE_SUPPRESS_SECS
                 } else {
                     // Spot recovered above the buffer — reset the timer
@@ -1340,7 +1348,7 @@ impl Strategy for GboostStrategyImpl {
             {
                 let lock_map = self.market_hold_locks.lock().unwrap();
                 if let Some(&lock_since) = lock_map.get(&target_market.condition_id) {
-                    let elapsed = lock_since.elapsed().as_secs() as i64;
+                    let elapsed = ctx.mono_now.duration_since(lock_since).as_secs() as i64;
                     if elapsed < config::GBOOST_MIN_HOLDING_LOCK_SECS {
                         veto!("market hold lock active");
                     }
@@ -1354,7 +1362,7 @@ impl Strategy for GboostStrategyImpl {
             if self.pending_entries.lock().unwrap().contains_key(&target_market.yes_token.clone()) {
                 return Ok(StrategySignal::NoSignal);
             }
-            if let Some(remaining_secs) = self.post_exit_cooldown_remaining_secs(target_market.yes_token.clone()) {
+            if let Some(remaining_secs) = self.post_exit_cooldown_remaining_secs(target_market.yes_token.clone(), ctx.wall_now) {
                 veto!(format!("cooldown active ({remaining_secs}s left)"));
             }
             let yes_obi = Self::side_obi(true, target_snapshot);
@@ -1437,7 +1445,7 @@ impl Strategy for GboostStrategyImpl {
             );
             // Record market-level hold lock to prevent rapid flip chop.
             self.market_hold_locks.lock().unwrap()
-                .insert(target_market.condition_id.clone(), Instant::now());
+                .insert(target_market.condition_id.clone(), ctx.mono_now);
             return Ok(StrategySignal::Entry {
                 params: OrderParams {
                     token_id: target_market.yes_token.clone(),
@@ -1464,7 +1472,7 @@ impl Strategy for GboostStrategyImpl {
             {
                 let lock_map = self.market_hold_locks.lock().unwrap();
                 if let Some(&lock_since) = lock_map.get(&target_market.condition_id) {
-                    let elapsed = lock_since.elapsed().as_secs() as i64;
+                    let elapsed = ctx.mono_now.duration_since(lock_since).as_secs() as i64;
                     if elapsed < config::GBOOST_MIN_HOLDING_LOCK_SECS {
                         veto!("market hold lock active");
                     }
@@ -1474,7 +1482,7 @@ impl Strategy for GboostStrategyImpl {
             if self.pending_entries.lock().unwrap().contains_key(&target_market.no_token.clone()) {
                 return Ok(StrategySignal::NoSignal);
             }
-            if let Some(remaining_secs) = self.post_exit_cooldown_remaining_secs(target_market.no_token.clone()) {
+            if let Some(remaining_secs) = self.post_exit_cooldown_remaining_secs(target_market.no_token.clone(), ctx.wall_now) {
                 veto!(format!("cooldown active ({remaining_secs}s left)"));
             }
             let no_obi = Self::side_obi(false, target_snapshot);
@@ -1547,7 +1555,7 @@ impl Strategy for GboostStrategyImpl {
             );
             // Record market-level hold lock to prevent rapid flip chop.
             self.market_hold_locks.lock().unwrap()
-                .insert(target_market.condition_id.clone(), Instant::now());
+                .insert(target_market.condition_id.clone(), ctx.mono_now);
             return Ok(StrategySignal::Entry {
                 params: OrderParams {
                     token_id: target_market.no_token.clone(),
@@ -1598,7 +1606,7 @@ impl Strategy for GboostStrategyImpl {
                     ((bid - pos.avg_entry) / pos.avg_entry).to_f64().unwrap_or(0.0)
                 } else { 0.0 };
                 let secs_held = pos.fill_confirmed_at
-                    .map(|t| (Utc::now() - t).num_seconds()).unwrap_or(0);
+                    .map(|t| (ctx.wall_now - t).num_seconds()).unwrap_or(0);
 
                 let exit_params = || OrderParams {
                     token_id: target_market.yes_token.clone(),
@@ -1614,7 +1622,7 @@ impl Strategy for GboostStrategyImpl {
 
                 if profit_pct >= tp {
                     self.record_training_outcome_on_exit(target_market.yes_token.clone(), profit_pct > 0.0);
-                    self.mark_post_exit_cooldown(target_market.yes_token.clone());
+                    self.mark_post_exit_cooldown(target_market.yes_token.clone(), ctx.wall_now);
                     return Ok(StrategySignal::Exit {
                         params: exit_params(),
                         reason: format!("GBoost TP YES: gain={:.2}%", profit_pct * 100.0),
@@ -1623,7 +1631,7 @@ impl Strategy for GboostStrategyImpl {
                 }
                 if secs_held >= config::GBOOST_SL_MIN_HOLD_SECS && profit_pct <= -sl {
                     self.record_training_outcome_on_exit(target_market.yes_token.clone(), profit_pct > 0.0);
-                    self.mark_post_exit_cooldown_sl(target_market.yes_token.clone());
+                    self.mark_post_exit_cooldown_sl(target_market.yes_token.clone(), ctx.wall_now);
                     return Ok(StrategySignal::Exit {
                         params: exit_params(),
                         reason: format!("GBoost SL YES: loss={:.2}% ({}s)", profit_pct * 100.0, secs_held),
@@ -1642,7 +1650,7 @@ impl Strategy for GboostStrategyImpl {
                         let half_sl = sl / 2.0;
                         if profit_pct >= config::GBOOST_SIGNAL_REV_MIN_PROFIT || profit_pct <= -half_sl {
                             self.record_training_outcome_on_exit(target_market.yes_token.clone(), profit_pct > 0.0);
-                            self.mark_post_exit_cooldown(target_market.yes_token.clone());
+                            self.mark_post_exit_cooldown(target_market.yes_token.clone(), ctx.wall_now);
                             return Ok(StrategySignal::Exit {
                                 params: exit_params(),
                                 reason: format!("GBoost SignalRev YES: P(UP)={:.3}", p),
@@ -1667,7 +1675,7 @@ impl Strategy for GboostStrategyImpl {
                     ((bid - pos.avg_entry) / pos.avg_entry).to_f64().unwrap_or(0.0)
                 } else { 0.0 };
                 let secs_held = pos.fill_confirmed_at
-                    .map(|t| (Utc::now() - t).num_seconds()).unwrap_or(0);
+                    .map(|t| (ctx.wall_now - t).num_seconds()).unwrap_or(0);
 
                 let exit_params = || OrderParams {
                     token_id: target_market.no_token.clone(),
@@ -1683,7 +1691,7 @@ impl Strategy for GboostStrategyImpl {
 
                 if profit_pct >= tp {
                     self.record_training_outcome_on_exit(target_market.no_token.clone(), profit_pct > 0.0);
-                    self.mark_post_exit_cooldown(target_market.no_token.clone());
+                    self.mark_post_exit_cooldown(target_market.no_token.clone(), ctx.wall_now);
                     return Ok(StrategySignal::Exit {
                         params: exit_params(),
                         reason: format!("GBoost TP NO: gain={:.2}%", profit_pct * 100.0),
@@ -1692,7 +1700,7 @@ impl Strategy for GboostStrategyImpl {
                 }
                 if secs_held >= config::GBOOST_SL_MIN_HOLD_SECS && profit_pct <= -sl {
                     self.record_training_outcome_on_exit(target_market.no_token.clone(), profit_pct > 0.0);
-                    self.mark_post_exit_cooldown_sl(target_market.no_token.clone());
+                    self.mark_post_exit_cooldown_sl(target_market.no_token.clone(), ctx.wall_now);
                     return Ok(StrategySignal::Exit {
                         params: exit_params(),
                         reason: format!("GBoost SL NO: loss={:.2}% ({}s)", profit_pct * 100.0, secs_held),
@@ -1708,7 +1716,7 @@ impl Strategy for GboostStrategyImpl {
                         let half_sl = sl / 2.0;
                         if profit_pct >= config::GBOOST_SIGNAL_REV_MIN_PROFIT || profit_pct <= -half_sl {
                             self.record_training_outcome_on_exit(target_market.no_token.clone(), profit_pct > 0.0);
-                            self.mark_post_exit_cooldown(target_market.no_token.clone());
+                            self.mark_post_exit_cooldown(target_market.no_token.clone(), ctx.wall_now);
                             return Ok(StrategySignal::Exit {
                                 params: exit_params(),
                                 reason: format!("GBoost SignalRev NO: P(UP)={:.3}", p),
@@ -1784,6 +1792,9 @@ mod tests {
             maker_snapshot: None, // Added missing field
             dynamic_config: Arc::new(DynamicConfig::default()),
             arb_market_lockouts: None,
+            wall_now: Utc::now(),
+            mono_now: Instant::now(),
+            is_replay: false,
         }
     }
 
@@ -1871,6 +1882,7 @@ mod tests {
                     pair_token_id: ctx.market.yes_token.clone(),
                     fill_confirmed_at: Some(Utc::now()),
                     paired_leg_token_id: None,
+                    ghost: false,
                 },
             );
         }
@@ -1904,6 +1916,7 @@ mod tests {
                     pair_token_id: ctx.market.yes_token.clone(),
                     fill_confirmed_at: Some(Utc::now()),
                     paired_leg_token_id: None,
+                    ghost: false,
                 },
             );
         }

--- a/src/vipers/maker_impl.rs
+++ b/src/vipers/maker_impl.rs
@@ -15,7 +15,6 @@
 
 use async_trait::async_trait;
 use anyhow::Result;
-use chrono::Utc;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::time::Instant;
@@ -75,14 +74,14 @@ impl Strategy for MakerStrategyImpl {
 
 
         // ── Market maturation gate ────────────────────────────────────────────
-        let secs_since_market_start = (Utc::now() - ctx.market_started_at).num_seconds();
+        let secs_since_market_start = (ctx.wall_now - ctx.market_started_at).num_seconds();
         if secs_since_market_start < config::MAKER_MIN_MARKET_AGE_SECS {
             return Ok(StrategySignal::NoSignal);
         }
 
         // ── Expiry gate ───────────────────────────────────────────────────────
         if let Some(close_time) = market.market_close_time {
-            if (close_time - Utc::now()).num_seconds() < config::MAKER_MIN_SECS_TO_EXPIRY {
+            if (close_time - ctx.wall_now).num_seconds() < config::MAKER_MIN_SECS_TO_EXPIRY {
                 return Ok(StrategySignal::NoSignal);
             }
         } else {
@@ -111,7 +110,7 @@ impl Strategy for MakerStrategyImpl {
         // one-sidedly — classic "toxic flow" that fills maker bids at adverse prices.
         // Suppress the affected side so we don't post into an active sweep.
         let (taker_flow_blocks_yes, taker_flow_blocks_no) = {
-            let now_inst = Instant::now();
+            let now_inst = ctx.mono_now;
             let mut prev_guard = self.prev_depths.lock().await;
 
             let drain_flags = if let Some(ref p) = *prev_guard {
@@ -301,7 +300,7 @@ impl Strategy for MakerStrategyImpl {
         let snapshot = ctx.maker_snapshot.as_ref().unwrap_or(&ctx.snapshot);
 
         let secs_to_expiry = market.market_close_time
-            .map(|t| (t - Utc::now()).num_seconds())
+            .map(|t| (t - ctx.wall_now).num_seconds())
             .unwrap_or(9999);
 
         // Near-expiry forced exit to avoid binary resolution risk
@@ -395,7 +394,7 @@ impl Strategy for MakerStrategyImpl {
 
             let profit_pct = (bid - position.avg_entry) / position.avg_entry;
             let secs_since_fill = position.fill_confirmed_at
-                .map(|t| (Utc::now() - t).num_seconds())
+                .map(|t| (ctx.wall_now - t).num_seconds())
                 .unwrap_or(0);
 
             if position.fill_confirmed_at.is_some() && profit_pct >= dc.maker_target_profit_pct {

--- a/src/vipers/momentum_impl.rs
+++ b/src/vipers/momentum_impl.rs
@@ -142,7 +142,7 @@ impl Strategy for MomentumStrategyImpl {
 
         // ── Expiry guard ──────────────────────────────────────────────────────
         if let Some(close_time) = ctx.market.market_close_time {
-            let secs_left = (close_time - chrono::Utc::now()).num_seconds();
+            let secs_left = (close_time - ctx.wall_now).num_seconds();
             if secs_left < config::MOMENTUM_MIN_SECS_TO_EXPIRY_FOR_ENTRY {
                 debug!(" Momentum entry blocked: only {}s to expiry (min {}s)",
                     secs_left, config::MOMENTUM_MIN_SECS_TO_EXPIRY_FOR_ENTRY);
@@ -162,7 +162,7 @@ impl Strategy for MomentumStrategyImpl {
         //   Heartbeat showed YES OBI=−0.94 (strongly adverse) but evaluation used
         //   the very first WS depth tick on the new subscription — book hadn't
         //   settled to its equilibrium state yet.
-        let secs_since_market_start = (chrono::Utc::now() - ctx.market_started_at).num_seconds();
+        let secs_since_market_start = (ctx.wall_now - ctx.market_started_at).num_seconds();
         if secs_since_market_start < config::MOMENTUM_MARKET_WARMUP_SECS {
             debug!(" Momentum entry blocked: market warmup period ({}s < {}s min)",
                 secs_since_market_start, config::MOMENTUM_MARKET_WARMUP_SECS);
@@ -170,7 +170,7 @@ impl Strategy for MomentumStrategyImpl {
         }
 
         // ── Snapshot staleness gate ───────────────────────────────────────────
-        let snap_age = (chrono::Utc::now() - ctx.snapshot.timestamp).num_seconds();
+        let snap_age = (ctx.wall_now - ctx.snapshot.timestamp).num_seconds();
         if snap_age > config::MOMENTUM_MAX_SNAPSHOT_AGE_SECS {
             debug!(" Momentum entry blocked: snapshot too stale ({}s > max {}s)",
                 snap_age, config::MOMENTUM_MAX_SNAPSHOT_AGE_SECS);
@@ -429,7 +429,7 @@ impl Strategy for MomentumStrategyImpl {
                 continue
             };
 
-            let secs_held = (chrono::Utc::now() - position.opened_at).num_seconds();
+            let secs_held = (ctx.wall_now - position.opened_at).num_seconds();
             if position.fill_confirmed_at.is_none() {
                 let profit_margin_check = (bid - position.avg_entry) / position.avg_entry;
                 if secs_held < config::MOMENTUM_FILL_CONFIRM_MIN_HOLD_SECS {
@@ -493,7 +493,7 @@ impl Strategy for MomentumStrategyImpl {
             // Use net profit (after sell offset) for the hold threshold so we don't
             // artificially "hold" a position that is break-even or negative net of costs.
             if let Some(close_time) = exit_close_time {
-                let secs_left = (close_time - chrono::Utc::now()).num_seconds();
+                let secs_left = (close_time - ctx.wall_now).num_seconds();
                 let net_profit_for_expiry = (bid - config::SELL_PRICE_OFFSET - avg_entry) / avg_entry;
                 if secs_left <= config::MOMENTUM_EXPIRY_EXIT_SECS && net_profit_for_expiry < config::MOMENTUM_EXPIRY_MIN_PROFIT_TO_HOLD {
                     let reason = format!("NearExpiry: bid=${:.4}, net_profit={:.2}%", bid, net_profit_for_expiry * dec!(100));

--- a/src/vipers/time_decay_impl.rs
+++ b/src/vipers/time_decay_impl.rs
@@ -69,7 +69,7 @@ impl Strategy for TimeDecayStrategyImpl {
         let (market, snap) = (&ctx.market, &ctx.snapshot);
 
         let seconds_to_expiry = match market.market_close_time {
-            Some(close_time) => (close_time - Utc::now()).num_seconds(),
+            Some(close_time) => (close_time - ctx.wall_now).num_seconds(),
             None => return Ok(StrategySignal::NoSignal),
         };
 
@@ -94,7 +94,7 @@ impl Strategy for TimeDecayStrategyImpl {
         // retains stale depth values — a book that appears neutral can actually be
         // adverse when the WebSocket hasn't fired recently.
         // 2026-05-07 T3: entered with entry_hb_age_sec=34, stale OBI slipped the gate.
-        let snapshot_age_secs = (Utc::now() - snap.timestamp).num_seconds();
+        let snapshot_age_secs = (ctx.wall_now - snap.timestamp).num_seconds();
         if snapshot_age_secs > config::TIME_DECAY_MAX_SNAPSHOT_AGE_SECS {
             tracing::debug!(
                 "🚫 TimeDecay entry blocked: snapshot too stale ({}s > max {}s)",
@@ -233,7 +233,7 @@ impl Strategy for TimeDecayStrategyImpl {
             };
 
             // ── Min-hold guard ────────────────────────────────────────────────
-            let hold_secs = (Utc::now() - yp.opened_at).num_seconds();
+            let hold_secs = (ctx.wall_now - yp.opened_at).num_seconds();
             if hold_secs < config::TIME_DECAY_MIN_HOLD_SECS {
                 tracing::debug!("⏳ TimeDecay SL suppressed: hold={}s < min={}s", hold_secs, config::TIME_DECAY_MIN_HOLD_SECS);
             } else {
@@ -257,7 +257,7 @@ impl Strategy for TimeDecayStrategyImpl {
 
             // ── Forced expiry exit ────────────────────────────────────────────
             if let Some(close_time) = market.market_close_time {
-                if (close_time - Utc::now()).num_seconds() < config::MARKET_EXPIRY_SAFETY_BUFFER_SECS as i64 {
+                if (close_time - ctx.wall_now).num_seconds() < config::MARKET_EXPIRY_SAFETY_BUFFER_SECS as i64 {
                     return Ok(StrategySignal::Exit {
                         params: OrderParams { token_id: market.yes_token.clone(), price: yes_bid, shares: yp.shares, fee_bps: market.yes_fee_bps as u16, is_neg_risk: market.is_neg_risk, market_name: market.market_name.clone(), condition_id: market.condition_id.clone(), order_type: TimeInForce::Fak, post_only: false, ghost_mode: dc.ghost_mode },
                         reason: "Time Decay Expiry".to_string(),

--- a/src/vipers/trendreversal_impl.rs
+++ b/src/vipers/trendreversal_impl.rs
@@ -61,7 +61,6 @@ use crate::venues::core::MarketId;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::Instant;
-use chrono::Utc;
 use tracing::debug;
 
 use crate::orchestrator::{Strategy, StrategyContext};
@@ -123,7 +122,7 @@ impl Strategy for TrendReversalStrategyImpl {
         };
 
         // ── Snapshot staleness gate ───────────────────────────────────────────
-        let snap_age = (Utc::now() - snap.timestamp).num_seconds();
+        let snap_age = (ctx.wall_now - snap.timestamp).num_seconds();
         if snap_age > config::TRENDCAPTURE_MAX_SNAPSHOT_AGE_SECS {
             debug!(" TrendCapture blocked: snapshot stale ({}s > {}s)",
                 snap_age, config::TRENDCAPTURE_MAX_SNAPSHOT_AGE_SECS);
@@ -141,7 +140,7 @@ impl Strategy for TrendReversalStrategyImpl {
 
         // ── Expiry guard ──────────────────────────────────────────────────────
         let secs_left = if let Some(close_time) = market.market_close_time {
-            let s = (close_time - Utc::now()).num_seconds();
+            let s = (close_time - ctx.wall_now).num_seconds();
             if s < config::TRENDCAPTURE_MIN_SECS_TO_EXPIRY {
                 debug!(" TrendCapture blocked: only {}s to expiry (min {}s)",
                     s, config::TRENDCAPTURE_MIN_SECS_TO_EXPIRY);
@@ -162,7 +161,7 @@ impl Strategy for TrendReversalStrategyImpl {
         };
 
         // ── Market warmup gate ────────────────────────────────────────────────
-        let secs_since_market_start = (Utc::now() - ctx.market_started_at).num_seconds();
+        let secs_since_market_start = (ctx.wall_now - ctx.market_started_at).num_seconds();
         if secs_since_market_start < config::TRENDCAPTURE_MARKET_WARMUP_SECS {
             return Ok(StrategySignal::NoSignal);
         }
@@ -228,7 +227,10 @@ impl Strategy for TrendReversalStrategyImpl {
         // of in-memory state. Runs only when |drift_10m| clears the entry trigger
         // (rare), so the query is cheap. Placed before the std-mutex cooldown locks
         // below so no guard is held across this await.
-        if config::TRENDREVERSAL_MODE {
+        // Skip the persistent guard under replay: the backtest harness shares the
+        // process DB pool registry, so this query would consult the LIVE bot's
+        // stop-loss history (read-only, but a fidelity leak). See ctx.is_replay.
+        if config::TRENDREVERSAL_MODE && !ctx.is_replay {
             let intended_side = if drift_10m <= bear_drift_10m_thr {
                 Some("YES")   // drift DOWN → fade UP → buy YES
             } else if drift_10m >= bull_drift_10m_thr {
@@ -423,7 +425,7 @@ impl Strategy for TrendReversalStrategyImpl {
                 let token_id = buy_token;
                 let cdl = effective_cooldown(&market.condition_id);
                 let in_cooldown = cooldowns.get(&token_id)
-                    .map(|t| t.elapsed().as_secs() < cdl)
+                    .map(|t| ctx.mono_now.duration_since(*t).as_secs() < cdl)
                     .unwrap_or(false);
                 if !in_cooldown {
                     let size = trade_size(drift_10m.abs());
@@ -489,7 +491,7 @@ impl Strategy for TrendReversalStrategyImpl {
                 let token_id = buy_token;
                 let cdl = effective_cooldown(&market.condition_id);
                 let in_cooldown = cooldowns.get(&token_id)
-                    .map(|t| t.elapsed().as_secs() < cdl)
+                    .map(|t| ctx.mono_now.duration_since(*t).as_secs() < cdl)
                     .unwrap_or(false);
                 if !in_cooldown {
                     let size = trade_size(drift_10m.abs());
@@ -536,7 +538,7 @@ impl Strategy for TrendReversalStrategyImpl {
         let soft_exit_cooldown_active = {
             let last = self.last_exit_signal_at.lock().unwrap();
             match *last {
-                Some(t) => t.elapsed().as_secs() < config::TRENDCAPTURE_EXIT_SIGNAL_COOLDOWN_SECS,
+                Some(t) => ctx.mono_now.duration_since(t).as_secs() < config::TRENDCAPTURE_EXIT_SIGNAL_COOLDOWN_SECS,
                 None => false,
             }
         };
@@ -558,7 +560,7 @@ impl Strategy for TrendReversalStrategyImpl {
 
         // Dynamic SL: tighter in the last hour before expiry
         let secs_left_opt = market.market_close_time
-            .map(|ct| (ct - Utc::now()).num_seconds());
+            .map(|ct| (ct - ctx.wall_now).num_seconds());
         // Tradelog/reason tag reflecting the active thesis.
         let tag = if config::TRENDREVERSAL_MODE { "TrendReversal" } else { "TrendCapture" };
 
@@ -612,7 +614,7 @@ impl Strategy for TrendReversalStrategyImpl {
                 let avg_entry = position.avg_entry;
                 if avg_entry <= dec!(0) { continue; }
 
-                let secs_held = (Utc::now() - position.opened_at).num_seconds();
+                let secs_held = (ctx.wall_now - position.opened_at).num_seconds();
 
                 // Wait for fill confirmation before any non-catastrophic exit
                 if position.fill_confirmed_at.is_none() {
@@ -656,7 +658,7 @@ impl Strategy for TrendReversalStrategyImpl {
 
                 // Near-expiry forced exit
                 if let Some(close_time) = market.market_close_time {
-                    let secs_left = (close_time - Utc::now()).num_seconds();
+                    let secs_left = (close_time - ctx.wall_now).num_seconds();
                     let net_profit = (bid - config::SELL_PRICE_OFFSET - avg_entry) / avg_entry;
                     if secs_left <= config::TRENDCAPTURE_EXPIRY_EXIT_SECS
                         && net_profit < config::TRENDCAPTURE_EXPIRY_MIN_PROFIT_TO_HOLD
@@ -720,10 +722,10 @@ impl Strategy for TrendReversalStrategyImpl {
         };
 
         if let Some(p) = pending {
-            self.record_exit(&p.token_id, &p.condition_id, p.is_sl);
+            self.record_exit(&p.token_id, &p.condition_id, p.is_sl, ctx.mono_now);
             // Stamp the exit signal cooldown to prevent FAK-miss re-fire storm
             if let Ok(mut last) = self.last_exit_signal_at.lock() {
-                *last = Some(Instant::now());
+                *last = Some(ctx.mono_now);
             }
             return Ok(StrategySignal::Exit {
                 params: OrderParams {
@@ -759,9 +761,9 @@ impl TrendReversalStrategyImpl {
     /// Record exit time for post-exit cooldown tracking.
     /// If `is_sl` is true, increments the consecutive-loss counter for the
     /// given condition_id; a TP exit resets it.
-    fn record_exit(&self, token_id: &MarketId, condition_id: &str, is_sl: bool) {
+    fn record_exit(&self, token_id: &MarketId, condition_id: &str, is_sl: bool, mono_now: Instant) {
         if let Ok(mut map) = self.post_exit_cooldown.lock() {
-            map.insert(token_id.clone(), Instant::now());
+            map.insert(token_id.clone(), mono_now);
         }
         if let Ok(mut losses) = self.consecutive_losses.lock() {
             if is_sl {

--- a/tests/hyperliquid_live.rs
+++ b/tests/hyperliquid_live.rs
@@ -1,0 +1,78 @@
+//! Live Hyperliquid mainnet smoke test — `#[ignore]`-gated so it never runs in
+//! normal `cargo test` (it hits the real network). Run it manually with:
+//!
+//!     cargo test --test hyperliquid_live -- --ignored
+//!
+//! It verifies the exact SDK message shapes the raptor parses: that within 60s
+//! we receive at least one `Trades` message with a parseable `px`, and at least
+//! one perp `ActiveAssetCtx` with parseable `funding` and `open_interest`.
+#![cfg(feature = "hyperliquid")]
+
+use std::str::FromStr;
+use std::time::Duration;
+
+use hyperliquid_rust_sdk::{AssetCtx, BaseUrl, InfoClient, Message, Subscription};
+use rust_decimal::Decimal;
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+#[tokio::test]
+#[ignore = "hits Hyperliquid mainnet over the network; run with --ignored"]
+async fn hyperliquid_live_trades_and_ctx_arrive() {
+    let mut client = InfoClient::new(None, Some(BaseUrl::Mainnet))
+        .await
+        .expect("build InfoClient against Hyperliquid mainnet");
+
+    let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+    client
+        .subscribe(Subscription::Trades { coin: "BTC".to_string() }, tx.clone())
+        .await
+        .expect("subscribe Trades{BTC}");
+    client
+        .subscribe(Subscription::ActiveAssetCtx { coin: "BTC".to_string() }, tx.clone())
+        .await
+        .expect("subscribe ActiveAssetCtx{BTC}");
+    drop(tx);
+
+    let mut got_trade = false;
+    let mut got_ctx = false;
+
+    // Bound the whole exchange to 60s.
+    let _ = timeout(Duration::from_secs(60), async {
+        while !(got_trade && got_ctx) {
+            match rx.recv().await {
+                Some(Message::Trades(trades)) => {
+                    for t in trades.data {
+                        assert!(
+                            Decimal::from_str(&t.px).is_ok(),
+                            "trade px should parse as Decimal, got {:?}",
+                            t.px
+                        );
+                        got_trade = true;
+                    }
+                }
+                Some(Message::ActiveAssetCtx(actx)) => {
+                    if let AssetCtx::Perps(perp) = actx.data.ctx {
+                        assert!(
+                            Decimal::from_str(&perp.funding).is_ok(),
+                            "funding should parse as Decimal, got {:?}",
+                            perp.funding
+                        );
+                        assert!(
+                            Decimal::from_str(&perp.open_interest).is_ok(),
+                            "open_interest should parse as Decimal, got {:?}",
+                            perp.open_interest
+                        );
+                        got_ctx = true;
+                    }
+                }
+                Some(_) => {}
+                None => break, // all senders dropped / socket closed
+            }
+        }
+    })
+    .await;
+
+    assert!(got_trade, "expected ≥1 Trades message within 60s");
+    assert!(got_ctx, "expected ≥1 perp ActiveAssetCtx message within 60s");
+}

--- a/tests/llm_live.rs
+++ b/tests/llm_live.rs
@@ -1,0 +1,147 @@
+//! Live end-to-end smoke tests for the Anthropic LLM backend
+//! (`src/helpers/llm_client.rs`) — `#[ignore]`-gated so they never run in
+//! normal `cargo test` (they hit real network APIs and cost real tokens).
+//!
+//! Run manually with:
+//!
+//!     ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY_SANDBOX" \
+//!         cargo test --test llm_live -- --ignored --nocapture
+//!
+//! SECURITY: these tests read `ANTHROPIC_API_KEY` from the environment and
+//! pass it straight into `LlmSettings`/`build_client()` (the same public path
+//! production uses). The key value itself is NEVER printed, logged, formatted,
+//! or otherwise written out by this file.
+
+use dradis::helpers::llm_client::{build_client, LlmProvider, LlmSettings};
+
+/// Model under test. If Anthropic ever rejects this id, retry with the alias
+/// `"claude-haiku-4-5"` (see task notes) — kept as a fallback constant so a
+/// human can flip it in one place.
+const MODEL: &str = "claude-haiku-4-5-20251001";
+
+/// Build an `LlmSettings` for the Anthropic provider through the exact same
+/// struct + `build_client()` constructor production code uses. Returns `None`
+/// (with an `eprintln!` skip message) when `ANTHROPIC_API_KEY` is unset so CI
+/// never breaks on a missing secret.
+fn anthropic_settings_from_env() -> Option<LlmSettings> {
+    let api_key = match std::env::var("ANTHROPIC_API_KEY") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => {
+            eprintln!(
+                "SKIP: ANTHROPIC_API_KEY not set in the environment — skipping live Anthropic test"
+            );
+            return None;
+        }
+    };
+
+    Some(LlmSettings {
+        provider: LlmProvider::Anthropic,
+        model: MODEL.to_string(),
+        base_url: None,
+        api_key: Some(api_key),
+        temperature: 0.0,
+        max_tokens: 32, // keep cost minimal — this is just a roundtrip probe
+        timeout_secs: 30,
+    })
+}
+
+#[tokio::test]
+#[ignore = "hits live APIs; needs ANTHROPIC_API_KEY"]
+async fn anthropic_live_chat_roundtrip() {
+    let settings = match anthropic_settings_from_env() {
+        Some(s) => s,
+        None => return,
+    };
+
+    let client = build_client(&settings).expect("build_client(Anthropic) should succeed");
+
+    // Sanity-check the model tag production code stores/renders — never
+    // touches the key.
+    let tag = client.model_tag();
+    assert!(
+        tag.starts_with("anthropic/"),
+        "expected model_tag to look like 'anthropic/<model>', got {tag:?}"
+    );
+
+    let reply = client
+        .chat("You are a terse test harness.", "Reply with exactly: PONG")
+        .await
+        .expect("anthropic chat() should succeed");
+
+    assert!(
+        !reply.trim().is_empty(),
+        "expected a non-empty reply from Anthropic"
+    );
+    eprintln!("anthropic_live_chat_roundtrip: model_tag={tag} reply={reply:?}");
+}
+
+#[tokio::test]
+#[ignore = "hits live APIs; needs ANTHROPIC_API_KEY"]
+async fn hyperliquid_plus_anthropic_smoke() {
+    let settings = match anthropic_settings_from_env() {
+        Some(s) => s,
+        None => return,
+    };
+
+    // ── Step 1: pull a real BTC candle from Hyperliquid (no cargo feature
+    // needed — this is a plain reqwest POST to the public /info endpoint). ──
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock should be after the epoch")
+        .as_millis() as i64;
+    let start_ms = now_ms - 3 * 60 * 60 * 1000;
+
+    let body = serde_json::json!({
+        "type": "candleSnapshot",
+        "req": {
+            "coin": "BTC",
+            "interval": "1h",
+            "startTime": start_ms,
+            "endTime": now_ms,
+        }
+    });
+
+    let http = reqwest::Client::new();
+    let resp = http
+        .post("https://api.hyperliquid.xyz/info")
+        .json(&body)
+        .send()
+        .await
+        .expect("hyperliquid /info request failed");
+
+    assert!(
+        resp.status().is_success(),
+        "hyperliquid /info returned HTTP {}",
+        resp.status()
+    );
+
+    let candles: Vec<serde_json::Value> = resp
+        .json()
+        .await
+        .expect("decoding hyperliquid candleSnapshot response");
+
+    let last = candles
+        .last()
+        .expect("expected at least one candle in the response");
+    let close_px = last
+        .get("c")
+        .and_then(|v| v.as_str())
+        .expect("candle should have a string 'c' (close) field");
+
+    // ── Step 2: feed the observed close price to the live Anthropic client. ──
+    let client = build_client(&settings).expect("build_client(Anthropic) should succeed");
+
+    let prompt = format!("BTC last close is {close_px}. Reply OK.");
+    let reply = client
+        .chat("You are a terse test harness.", &prompt)
+        .await
+        .expect("anthropic chat() should succeed");
+
+    assert!(
+        !reply.trim().is_empty(),
+        "expected a non-empty reply from Anthropic"
+    );
+    eprintln!(
+        "hyperliquid_plus_anthropic_smoke: close_px={close_px} reply={reply:?}"
+    );
+}

--- a/tests/toctou.rs
+++ b/tests/toctou.rs
@@ -31,6 +31,7 @@ fn make_position(token_id: &str) -> Position {
         pair_token_id: MarketId::new(token_id),
         fill_confirmed_at: None,
         paired_leg_token_id: None,
+        ghost: false,
     }
 }
 


### PR DESCRIPTION
Adds four opt-in capabilities on top of the existing engine. All are additive:
with no new configuration, the bot behaves exactly as it does today (Binance
market data, ollama LLM advisor, live trading, no backtest dependencies).

## Hyperliquid market-data source

- Runtime-selectable via `MARKET_DATA_SOURCE` (`binance` | `hyperliquid`).
- Defaults to `binance`.
- Gated by the additive `hyperliquid` cargo feature.
- With the feature stripped, the engine compiles and falls back to Binance.
- One raptor per asset feeds the same five channels as the Binance raptors
  (oracle price, velocity, drift, funding, derivatives).
- Viper/Squadron layers are source-agnostic.
- Hourly funding normalized to 8h equivalents.
- Kinematics resampled at 1 Hz to match Binance ticker cadence.
- Introduces `raptors/source.rs` (source abstraction) and
  `raptors/kinematics.rs`.

## Multi-provider LLM advisor

- Generalizes the existing advisor behind an `LlmChat` trait
  (`helpers/llm_client.rs`).
- Providers: `ollama` (wire format unchanged), `anthropic`, `openai`,
  `openai-compatible` (vLLM, LM Studio, OpenRouter, Groq, ...), and `chatgpt`
  (OAuth), via `rig-core`.
- Provider and model are recorded per recommendation.
- Provider and model are surfaced in the Control Tower.
- Existing deployments that only set `OLLAMA_URL` / `OLLAMA_MODEL` keep working
  with no changes.

## Paper trading (ghost mode)

- Position-scoped ghost mode with a runtime-effective GHOST/LIVE toggle.
- Toggle propagates via 30s squadron config reload and global PATCH fan-out.
- Depth-aware simulated fills.
- Resting maker quotes.
- Binary-expiry settlement.
- Segregated paper ledger with `paper_pnl` and `ghost` columns on the trades
  and entries tables.
- Paper and live results never mix.

## Backtesting

- Behind a non-default `backtest` cargo feature (keeps the default build free
  of the plotting/font stack).
- Historical data providers behind a `HistoricalSource` trait
  (`src/backtest/source/`), mirroring the `LlmChat` pattern: one factory, one
  file + one enum variant + one match arm per new provider.
- Runtime-selectable via `--source` (`hyperliquid` | `binance`). Defaults to
  `hyperliquid`.
- Binance provider reads FAPI perpetual futures — candles and funding from the
  same instrument, no ~5000-candle retention limit.
- No API keys: both providers hit public, unauthenticated endpoints.
- SQLite cache keyed by `(source, coin, interval, ts)` so providers never
  collide; pre-existing caches migrate in place (data-preserving, tagged
  `hyperliquid`).
- Funding cached raw in the provider's native cadence; normalization
  generalized to `normalize_funding(rate, period_hours)` (Hyperliquid 1h,
  Binance 8h).
- Still-forming candles are rejected centrally in the cache insert path, so no
  provider can freeze a provisional bar.
- Unsupported `--interval` values are a hard error, never a silent default.
- CLI rewritten on clap derive (`src/bin/backtest.rs`); legacy flags unchanged,
  `--help`/`--version` generated.
- Clock seam (`wall_now` / `mono_now`) threaded through `StrategyContext` and
  all Vipers.
- Snapshot synthesis with a parametric book model.
- `Decimal` ledger with binary settlement.
- Directional-proxy metrics.
- Optional LLM decision scoring.
- Ships the CLI binary, a feature-gated API (`source` selectable per run, bad
  values → 400), and a Control Tower Backtest tab.

## Control Tower

- Backtest tab.
- Live/Paper trade-log filter.
- Paper equity sparkline.
- Provider/model and data-source chips.

## Configuration (all optional)

| Variable                                                        | Purpose                                                            | Default          |
| --------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------- |
| `MARKET_DATA_SOURCE`                                            | `binance` or `hyperliquid`                                         | `binance`        |
| `LLM_PROVIDER`                                                  | `ollama`, `anthropic`, `openai`, `openai-compatible`, or `chatgpt` | `ollama`         |
| `LLM_MODEL` / `LLM_BASE_URL`                                    | Model and endpoint override for the selected provider              | provider default |
| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `CHATGPT_ACCESS_TOKEN` | Cloud-provider credentials                                         | unset            |

See `.env.example` for the full annotated list. Cargo features: `hyperliquid`
(additive, in `default`) and `backtest` (non-default; pulls `clap`; needs
`libfontconfig1-dev` and `pkg-config`). Backtest data sources are CLI/API
selections, not env vars or features, and need no credentials.

**Verification:**

- CI matrix proves the features are cleanly strippable: `cargo check`
  (default), `cargo check --no-default-features --features intl_clob`
  (Hyperliquid stripped, Binance fallback), and
  `cargo check --features backtest`.
- Test suite passes, including regression tests for cross-source cache
  isolation, in-place legacy-cache migration (idempotent re-open), the
  still-forming-candle guard, and provider wire-format parsing fixtures.
- Both backtest sources smoke-tested live: same window replayed from
  Hyperliquid and Binance, rerun served from cache, both sources' rows
  coexisting in one cache file.
- Live network tests (`tests/hyperliquid_live.rs`, `tests/llm_live.rs`) are
  behind `#[ignore]`.

**Notes:**

- Fully backward compatible. Binance remains the default source, ollama the
  default advisor, live trading the default mode, and `backtest` is off by
  default. Each capability activates only when its env var or cargo feature is
  set.
- Branched from `main` and fully merged up to current upstream `main`
  (sports-raptor stats, `spawn_supervised`, the trade-recording PnL fix, etc.).
- The bulk of the diff is new, isolated modules (`src/backtest/*` including
  `src/backtest/source/*`, `src/helpers/llm_client.rs`,
  `src/raptors/hyperliquid.rs`, `src/raptors/source.rs`,
  `src/helpers/paper.rs`) plus the Control Tower tab. Changes to existing files
  are mostly the source abstractions and the clock seam threaded through the
  Vipers.